### PR TITLE
Update Euro 2025 final details and tags

### DIFF
--- a/src/_content/games/euro-2025/final.md
+++ b/src/_content/games/euro-2025/final.md
@@ -1,10 +1,10 @@
 ---
-title: Final
+title: England v Spain
 date: 2025-07-27T16:00Z
 endDate: 2025-07-27T18:00Z
 locationName: St. Jakob‑Park, Basel
 path: /euro-2025/final/
-tags: ["Final", "St. Jakob‑Park, Basel", "EURO 2025"]
+tags: ["Final", "St. Jakob‑Park, Basel", "EURO 2025", "England", "Spain"]
 tv: ["BBC", "ITV"]
 ---
-The final of the Women's Euro 2025 competition. 
+The final of the Women's Euro 2025 competition will be contested between England and Spain. 


### PR DESCRIPTION
Update Euro 2025 final details to reflect England v Spain and add team names to tags.

---

[Open in Web](https://www.cursor.com/agents?id=bc-185c2956-71e1-4164-9fcb-903e03967028) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-185c2956-71e1-4164-9fcb-903e03967028)