### PR TITLE
Add FIFA World Cup 2026 group stage fixtures

### DIFF
--- a/src/_content/games/world-cup-2026/algeria-austria.md
+++ b/src/_content/games/world-cup-2026/algeria-austria.md
@@ -4,7 +4,7 @@ date: 2026-06-28T02:00Z
 endDate: 2026-06-28T03:50Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/algeria-austria/
-tags: ["Algeria","Austria","Kansas City","Group J","Group stages","FIFA World Cup 2026"]
+tags: ["Algeria","Austria","Kansas City","Group J","Group stages","World Cup 2026"]
 tv: []
 ---
 The 59th game of the FIFA World Cup 2026 group stage between Group J competitors, Algeria and Austria.

--- a/src/_content/games/world-cup-2026/algeria-austria.md
+++ b/src/_content/games/world-cup-2026/algeria-austria.md
@@ -1,0 +1,10 @@
+---
+title: "Algeria v Austria"
+date: 2026-06-28T02:00Z
+endDate: 2026-06-28T03:50Z
+locationName: "Arrowhead Stadium, Kansas City"
+path: /world-cup-2026/algeria-austria/
+tags: ["Algeria","Austria","Kansas City","Group J","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 59th game of the FIFA World Cup 2026 group stage between Group J competitors, Algeria and Austria.

--- a/src/_content/games/world-cup-2026/argentina-algeria.md
+++ b/src/_content/games/world-cup-2026/argentina-algeria.md
@@ -4,7 +4,7 @@ date: 2026-06-17T01:00Z
 endDate: 2026-06-17T02:50Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/argentina-algeria/
-tags: ["Argentina","Algeria","Kansas City","Group J","Group stages","FIFA World Cup 2026"]
+tags: ["Argentina","Algeria","Kansas City","Group J","Group stages","World Cup 2026"]
 tv: []
 ---
 The 55th game of the FIFA World Cup 2026 group stage between Group J competitors, Argentina and Algeria.

--- a/src/_content/games/world-cup-2026/argentina-algeria.md
+++ b/src/_content/games/world-cup-2026/argentina-algeria.md
@@ -1,0 +1,10 @@
+---
+title: "Argentina v Algeria"
+date: 2026-06-17T01:00Z
+endDate: 2026-06-17T02:50Z
+locationName: "Arrowhead Stadium, Kansas City"
+path: /world-cup-2026/argentina-algeria/
+tags: ["Argentina","Algeria","Kansas City","Group J","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 55th game of the FIFA World Cup 2026 group stage between Group J competitors, Argentina and Algeria.

--- a/src/_content/games/world-cup-2026/argentina-austria.md
+++ b/src/_content/games/world-cup-2026/argentina-austria.md
@@ -4,7 +4,7 @@ date: 2026-06-22T18:00Z
 endDate: 2026-06-22T19:50Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/argentina-austria/
-tags: ["Argentina","Austria","Dallas","Group J","Group stages","FIFA World Cup 2026"]
+tags: ["Argentina","Austria","Dallas","Group J","Group stages","World Cup 2026"]
 tv: []
 ---
 The 57th game of the FIFA World Cup 2026 group stage between Group J competitors, Argentina and Austria.

--- a/src/_content/games/world-cup-2026/argentina-austria.md
+++ b/src/_content/games/world-cup-2026/argentina-austria.md
@@ -1,0 +1,10 @@
+---
+title: "Argentina v Austria"
+date: 2026-06-22T18:00Z
+endDate: 2026-06-22T19:50Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/argentina-austria/
+tags: ["Argentina","Austria","Dallas","Group J","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 57th game of the FIFA World Cup 2026 group stage between Group J competitors, Argentina and Austria.

--- a/src/_content/games/world-cup-2026/australia-uefa-playoff-c.md
+++ b/src/_content/games/world-cup-2026/australia-uefa-playoff-c.md
@@ -1,0 +1,10 @@
+---
+title: "Australia v UEFA Playoff C"
+date: 2026-06-14T04:00Z
+endDate: 2026-06-14T05:50Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/australia-uefa-playoff-c/
+tags: ["Australia","UEFA Playoff C","Vancouver","Group D","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 20th game of the FIFA World Cup 2026 group stage between Group D competitors, Australia and UEFA Playoff C.

--- a/src/_content/games/world-cup-2026/australia-uefa-playoff-c.md
+++ b/src/_content/games/world-cup-2026/australia-uefa-playoff-c.md
@@ -4,7 +4,7 @@ date: 2026-06-14T04:00Z
 endDate: 2026-06-14T05:50Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/australia-uefa-playoff-c/
-tags: ["Australia","UEFA Playoff C","Vancouver","Group D","Group stages","FIFA World Cup 2026"]
+tags: ["Australia","UEFA Playoff C","Vancouver","Group D","Group stages","World Cup 2026"]
 tv: []
 ---
 The 20th game of the FIFA World Cup 2026 group stage between Group D competitors, Australia and UEFA Playoff C.

--- a/src/_content/games/world-cup-2026/austria-jordan.md
+++ b/src/_content/games/world-cup-2026/austria-jordan.md
@@ -1,0 +1,10 @@
+---
+title: "Austria v Jordan"
+date: 2026-06-17T04:00Z
+endDate: 2026-06-17T05:50Z
+locationName: "Levi's Stadium, San Francisco"
+path: /world-cup-2026/austria-jordan/
+tags: ["Austria","Jordan","San Francisco","Group J","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 56th game of the FIFA World Cup 2026 group stage between Group J competitors, Austria and Jordan.

--- a/src/_content/games/world-cup-2026/austria-jordan.md
+++ b/src/_content/games/world-cup-2026/austria-jordan.md
@@ -4,7 +4,7 @@ date: 2026-06-17T04:00Z
 endDate: 2026-06-17T05:50Z
 locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/austria-jordan/
-tags: ["Austria","Jordan","San Francisco","Group J","Group stages","FIFA World Cup 2026"]
+tags: ["Austria","Jordan","San Francisco","Group J","Group stages","World Cup 2026"]
 tv: []
 ---
 The 56th game of the FIFA World Cup 2026 group stage between Group J competitors, Austria and Jordan.

--- a/src/_content/games/world-cup-2026/belgium-egypt.md
+++ b/src/_content/games/world-cup-2026/belgium-egypt.md
@@ -1,0 +1,10 @@
+---
+title: "Belgium v Egypt"
+date: 2026-06-15T19:00Z
+endDate: 2026-06-15T20:50Z
+locationName: "Lumen Field, Seattle"
+path: /world-cup-2026/belgium-egypt/
+tags: ["Belgium","Egypt","Seattle","Group G","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 37th game of the FIFA World Cup 2026 group stage between Group G competitors, Belgium and Egypt.

--- a/src/_content/games/world-cup-2026/belgium-egypt.md
+++ b/src/_content/games/world-cup-2026/belgium-egypt.md
@@ -4,7 +4,7 @@ date: 2026-06-15T19:00Z
 endDate: 2026-06-15T20:50Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/belgium-egypt/
-tags: ["Belgium","Egypt","Seattle","Group G","Group stages","FIFA World Cup 2026"]
+tags: ["Belgium","Egypt","Seattle","Group G","Group stages","World Cup 2026"]
 tv: []
 ---
 The 37th game of the FIFA World Cup 2026 group stage between Group G competitors, Belgium and Egypt.

--- a/src/_content/games/world-cup-2026/belgium-iran.md
+++ b/src/_content/games/world-cup-2026/belgium-iran.md
@@ -1,0 +1,10 @@
+---
+title: "Belgium v Iran"
+date: 2026-06-21T19:00Z
+endDate: 2026-06-21T20:50Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/belgium-iran/
+tags: ["Belgium","Iran","Los Angeles","Group G","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 39th game of the FIFA World Cup 2026 group stage between Group G competitors, Belgium and Iran.

--- a/src/_content/games/world-cup-2026/belgium-iran.md
+++ b/src/_content/games/world-cup-2026/belgium-iran.md
@@ -4,7 +4,7 @@ date: 2026-06-21T19:00Z
 endDate: 2026-06-21T20:50Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/belgium-iran/
-tags: ["Belgium","Iran","Los Angeles","Group G","Group stages","FIFA World Cup 2026"]
+tags: ["Belgium","Iran","Los Angeles","Group G","Group stages","World Cup 2026"]
 tv: []
 ---
 The 39th game of the FIFA World Cup 2026 group stage between Group G competitors, Belgium and Iran.

--- a/src/_content/games/world-cup-2026/brazil-haiti.md
+++ b/src/_content/games/world-cup-2026/brazil-haiti.md
@@ -1,0 +1,10 @@
+---
+title: "Brazil v Haiti"
+date: 2026-06-20T01:00Z
+endDate: 2026-06-20T02:50Z
+locationName: "Lincoln Financial Field, Philadelphia"
+path: /world-cup-2026/brazil-haiti/
+tags: ["Brazil","Haiti","Philadelphia","Group C","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 16th game of the FIFA World Cup 2026 group stage between Group C competitors, Brazil and Haiti.

--- a/src/_content/games/world-cup-2026/brazil-haiti.md
+++ b/src/_content/games/world-cup-2026/brazil-haiti.md
@@ -4,7 +4,7 @@ date: 2026-06-20T01:00Z
 endDate: 2026-06-20T02:50Z
 locationName: "Lincoln Financial Field, Philadelphia"
 path: /world-cup-2026/brazil-haiti/
-tags: ["Brazil","Haiti","Philadelphia","Group C","Group stages","FIFA World Cup 2026"]
+tags: ["Brazil","Haiti","Philadelphia","Group C","Group stages","World Cup 2026"]
 tv: []
 ---
 The 16th game of the FIFA World Cup 2026 group stage between Group C competitors, Brazil and Haiti.

--- a/src/_content/games/world-cup-2026/brazil-morocco.md
+++ b/src/_content/games/world-cup-2026/brazil-morocco.md
@@ -4,7 +4,7 @@ date: 2026-06-13T22:00Z
 endDate: 2026-06-13T23:50Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/brazil-morocco/
-tags: ["Brazil","Morocco","New York New Jersey","Group C","Group stages","FIFA World Cup 2026"]
+tags: ["Brazil","Morocco","New York New Jersey","Group C","Group stages","World Cup 2026"]
 tv: []
 ---
 The 13th game of the FIFA World Cup 2026 group stage between Group C competitors, Brazil and Morocco.

--- a/src/_content/games/world-cup-2026/brazil-morocco.md
+++ b/src/_content/games/world-cup-2026/brazil-morocco.md
@@ -1,0 +1,10 @@
+---
+title: "Brazil v Morocco"
+date: 2026-06-13T22:00Z
+endDate: 2026-06-13T23:50Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/brazil-morocco/
+tags: ["Brazil","Morocco","New York New Jersey","Group C","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 13th game of the FIFA World Cup 2026 group stage between Group C competitors, Brazil and Morocco.

--- a/src/_content/games/world-cup-2026/canada-qatar.md
+++ b/src/_content/games/world-cup-2026/canada-qatar.md
@@ -4,7 +4,7 @@ date: 2026-06-18T22:00Z
 endDate: 2026-06-18T23:50Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/canada-qatar/
-tags: ["Canada","Qatar","Vancouver","Group B","Group stages","FIFA World Cup 2026"]
+tags: ["Canada","Qatar","Vancouver","Group B","Group stages","World Cup 2026"]
 tv: []
 ---
 The 10th game of the FIFA World Cup 2026 group stage between Group B competitors, Canada and Qatar.

--- a/src/_content/games/world-cup-2026/canada-qatar.md
+++ b/src/_content/games/world-cup-2026/canada-qatar.md
@@ -1,0 +1,10 @@
+---
+title: "Canada v Qatar"
+date: 2026-06-18T22:00Z
+endDate: 2026-06-18T23:50Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/canada-qatar/
+tags: ["Canada","Qatar","Vancouver","Group B","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 10th game of the FIFA World Cup 2026 group stage between Group B competitors, Canada and Qatar.

--- a/src/_content/games/world-cup-2026/canada-uefa-playoff-a.md
+++ b/src/_content/games/world-cup-2026/canada-uefa-playoff-a.md
@@ -1,0 +1,10 @@
+---
+title: "Canada v UEFA Playoff A"
+date: 2026-06-12T19:00Z
+endDate: 2026-06-12T20:50Z
+locationName: "BMO Field, Toronto"
+path: /world-cup-2026/canada-uefa-playoff-a/
+tags: ["Canada","UEFA Playoff A","Toronto","Group B","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 7th game of the FIFA World Cup 2026 group stage between Group B competitors, Canada and UEFA Playoff A.

--- a/src/_content/games/world-cup-2026/canada-uefa-playoff-a.md
+++ b/src/_content/games/world-cup-2026/canada-uefa-playoff-a.md
@@ -4,7 +4,7 @@ date: 2026-06-12T19:00Z
 endDate: 2026-06-12T20:50Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/canada-uefa-playoff-a/
-tags: ["Canada","UEFA Playoff A","Toronto","Group B","Group stages","FIFA World Cup 2026"]
+tags: ["Canada","UEFA Playoff A","Toronto","Group B","Group stages","World Cup 2026"]
 tv: []
 ---
 The 7th game of the FIFA World Cup 2026 group stage between Group B competitors, Canada and UEFA Playoff A.

--- a/src/_content/games/world-cup-2026/cape-verde-saudi-arabia.md
+++ b/src/_content/games/world-cup-2026/cape-verde-saudi-arabia.md
@@ -4,7 +4,7 @@ date: 2026-06-27T00:00Z
 endDate: 2026-06-27T01:50Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/cape-verde-saudi-arabia/
-tags: ["Cape Verde","Saudi Arabia","Houston","Group H","Group stages","FIFA World Cup 2026"]
+tags: ["Cape Verde","Saudi Arabia","Houston","Group H","Group stages","World Cup 2026"]
 tv: []
 ---
 The 47th game of the FIFA World Cup 2026 group stage between Group H competitors, Cape Verde and Saudi Arabia.

--- a/src/_content/games/world-cup-2026/cape-verde-saudi-arabia.md
+++ b/src/_content/games/world-cup-2026/cape-verde-saudi-arabia.md
@@ -1,0 +1,10 @@
+---
+title: "Cape Verde v Saudi Arabia"
+date: 2026-06-27T00:00Z
+endDate: 2026-06-27T01:50Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/cape-verde-saudi-arabia/
+tags: ["Cape Verde","Saudi Arabia","Houston","Group H","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 47th game of the FIFA World Cup 2026 group stage between Group H competitors, Cape Verde and Saudi Arabia.

--- a/src/_content/games/world-cup-2026/colombia-ic-playoff-1.md
+++ b/src/_content/games/world-cup-2026/colombia-ic-playoff-1.md
@@ -4,7 +4,7 @@ date: 2026-06-24T03:00Z
 endDate: 2026-06-24T04:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/colombia-ic-playoff-1/
-tags: ["Colombia","IC Playoff 1","Guadalajara","Group K","Group stages","FIFA World Cup 2026"]
+tags: ["Colombia","IC Playoff 1","Guadalajara","Group K","Group stages","World Cup 2026"]
 tv: []
 ---
 The 64th game of the FIFA World Cup 2026 group stage between Group K competitors, Colombia and IC Playoff 1.

--- a/src/_content/games/world-cup-2026/colombia-ic-playoff-1.md
+++ b/src/_content/games/world-cup-2026/colombia-ic-playoff-1.md
@@ -1,0 +1,10 @@
+---
+title: "Colombia v IC Playoff 1"
+date: 2026-06-24T03:00Z
+endDate: 2026-06-24T04:50Z
+locationName: "Estadio Akron, Guadalajara"
+path: /world-cup-2026/colombia-ic-playoff-1/
+tags: ["Colombia","IC Playoff 1","Guadalajara","Group K","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 64th game of the FIFA World Cup 2026 group stage between Group K competitors, Colombia and IC Playoff 1.

--- a/src/_content/games/world-cup-2026/colombia-portugal.md
+++ b/src/_content/games/world-cup-2026/colombia-portugal.md
@@ -1,0 +1,10 @@
+---
+title: "Colombia v Portugal"
+date: 2026-06-27T23:30Z
+endDate: 2026-06-28T01:20Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/colombia-portugal/
+tags: ["Colombia","Portugal","Miami","Group K","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 65th game of the FIFA World Cup 2026 group stage between Group K competitors, Colombia and Portugal.

--- a/src/_content/games/world-cup-2026/colombia-portugal.md
+++ b/src/_content/games/world-cup-2026/colombia-portugal.md
@@ -4,7 +4,7 @@ date: 2026-06-27T23:30Z
 endDate: 2026-06-28T01:20Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/colombia-portugal/
-tags: ["Colombia","Portugal","Miami","Group K","Group stages","FIFA World Cup 2026"]
+tags: ["Colombia","Portugal","Miami","Group K","Group stages","World Cup 2026"]
 tv: []
 ---
 The 65th game of the FIFA World Cup 2026 group stage between Group K competitors, Colombia and Portugal.

--- a/src/_content/games/world-cup-2026/croatia-ghana.md
+++ b/src/_content/games/world-cup-2026/croatia-ghana.md
@@ -1,0 +1,10 @@
+---
+title: "Croatia v Ghana"
+date: 2026-06-27T21:00Z
+endDate: 2026-06-27T22:50Z
+locationName: "Lincoln Financial Field, Philadelphia"
+path: /world-cup-2026/croatia-ghana/
+tags: ["Croatia","Ghana","Philadelphia","Group L","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 72nd game of the FIFA World Cup 2026 group stage between Group L competitors, Croatia and Ghana.

--- a/src/_content/games/world-cup-2026/croatia-ghana.md
+++ b/src/_content/games/world-cup-2026/croatia-ghana.md
@@ -4,7 +4,7 @@ date: 2026-06-27T21:00Z
 endDate: 2026-06-27T22:50Z
 locationName: "Lincoln Financial Field, Philadelphia"
 path: /world-cup-2026/croatia-ghana/
-tags: ["Croatia","Ghana","Philadelphia","Group L","Group stages","FIFA World Cup 2026"]
+tags: ["Croatia","Ghana","Philadelphia","Group L","Group stages","World Cup 2026"]
 tv: []
 ---
 The 72nd game of the FIFA World Cup 2026 group stage between Group L competitors, Croatia and Ghana.

--- a/src/_content/games/world-cup-2026/curacao-ivory-coast.md
+++ b/src/_content/games/world-cup-2026/curacao-ivory-coast.md
@@ -4,7 +4,7 @@ date: 2026-06-25T20:00Z
 endDate: 2026-06-25T21:50Z
 locationName: "Lincoln Financial Field, Philadelphia"
 path: /world-cup-2026/curacao-ivory-coast/
-tags: ["Curaçao","Ivory Coast","Philadelphia","Group E","Group stages","FIFA World Cup 2026"]
+tags: ["Curaçao","Ivory Coast","Philadelphia","Group E","Group stages","World Cup 2026"]
 tv: []
 ---
 The 30th game of the FIFA World Cup 2026 group stage between Group E competitors, Curaçao and Ivory Coast.

--- a/src/_content/games/world-cup-2026/curacao-ivory-coast.md
+++ b/src/_content/games/world-cup-2026/curacao-ivory-coast.md
@@ -1,0 +1,10 @@
+---
+title: "Curaçao v Ivory Coast"
+date: 2026-06-25T20:00Z
+endDate: 2026-06-25T21:50Z
+locationName: "Lincoln Financial Field, Philadelphia"
+path: /world-cup-2026/curacao-ivory-coast/
+tags: ["Curaçao","Ivory Coast","Philadelphia","Group E","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 30th game of the FIFA World Cup 2026 group stage between Group E competitors, Curaçao and Ivory Coast.

--- a/src/_content/games/world-cup-2026/ecuador-curacao.md
+++ b/src/_content/games/world-cup-2026/ecuador-curacao.md
@@ -4,7 +4,7 @@ date: 2026-06-21T00:00Z
 endDate: 2026-06-21T01:50Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/ecuador-curacao/
-tags: ["Ecuador","Curaçao","Kansas City","Group E","Group stages","FIFA World Cup 2026"]
+tags: ["Ecuador","Curaçao","Kansas City","Group E","Group stages","World Cup 2026"]
 tv: []
 ---
 The 28th game of the FIFA World Cup 2026 group stage between Group E competitors, Ecuador and Curaçao.

--- a/src/_content/games/world-cup-2026/ecuador-curacao.md
+++ b/src/_content/games/world-cup-2026/ecuador-curacao.md
@@ -1,0 +1,10 @@
+---
+title: "Ecuador v Curaçao"
+date: 2026-06-21T00:00Z
+endDate: 2026-06-21T01:50Z
+locationName: "Arrowhead Stadium, Kansas City"
+path: /world-cup-2026/ecuador-curacao/
+tags: ["Ecuador","Curaçao","Kansas City","Group E","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 28th game of the FIFA World Cup 2026 group stage between Group E competitors, Ecuador and Curaçao.

--- a/src/_content/games/world-cup-2026/ecuador-germany.md
+++ b/src/_content/games/world-cup-2026/ecuador-germany.md
@@ -4,7 +4,7 @@ date: 2026-06-25T20:00Z
 endDate: 2026-06-25T21:50Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/ecuador-germany/
-tags: ["Ecuador","Germany","New York New Jersey","Group E","Group stages","FIFA World Cup 2026"]
+tags: ["Ecuador","Germany","New York New Jersey","Group E","Group stages","World Cup 2026"]
 tv: []
 ---
 The 29th game of the FIFA World Cup 2026 group stage between Group E competitors, Ecuador and Germany.

--- a/src/_content/games/world-cup-2026/ecuador-germany.md
+++ b/src/_content/games/world-cup-2026/ecuador-germany.md
@@ -1,0 +1,10 @@
+---
+title: "Ecuador v Germany"
+date: 2026-06-25T20:00Z
+endDate: 2026-06-25T21:50Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/ecuador-germany/
+tags: ["Ecuador","Germany","New York New Jersey","Group E","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 29th game of the FIFA World Cup 2026 group stage between Group E competitors, Ecuador and Germany.

--- a/src/_content/games/world-cup-2026/egypt-iran.md
+++ b/src/_content/games/world-cup-2026/egypt-iran.md
@@ -4,7 +4,7 @@ date: 2026-06-27T03:00Z
 endDate: 2026-06-27T04:50Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/egypt-iran/
-tags: ["Egypt","Iran","Seattle","Group G","Group stages","FIFA World Cup 2026"]
+tags: ["Egypt","Iran","Seattle","Group G","Group stages","World Cup 2026"]
 tv: []
 ---
 The 41st game of the FIFA World Cup 2026 group stage between Group G competitors, Egypt and Iran.

--- a/src/_content/games/world-cup-2026/egypt-iran.md
+++ b/src/_content/games/world-cup-2026/egypt-iran.md
@@ -1,0 +1,10 @@
+---
+title: "Egypt v Iran"
+date: 2026-06-27T03:00Z
+endDate: 2026-06-27T04:50Z
+locationName: "Lumen Field, Seattle"
+path: /world-cup-2026/egypt-iran/
+tags: ["Egypt","Iran","Seattle","Group G","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 41st game of the FIFA World Cup 2026 group stage between Group G competitors, Egypt and Iran.

--- a/src/_content/games/world-cup-2026/england-croatia.md
+++ b/src/_content/games/world-cup-2026/england-croatia.md
@@ -4,7 +4,7 @@ date: 2026-06-17T20:00Z
 endDate: 2026-06-17T21:50Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/england-croatia/
-tags: ["England","Croatia","Dallas","Group L","Group stages","FIFA World Cup 2026"]
+tags: ["England","Croatia","Dallas","Group L","Group stages","World Cup 2026"]
 tv: []
 ---
 The 67th game of the FIFA World Cup 2026 group stage between Group L competitors, England and Croatia.

--- a/src/_content/games/world-cup-2026/england-croatia.md
+++ b/src/_content/games/world-cup-2026/england-croatia.md
@@ -1,0 +1,10 @@
+---
+title: "England v Croatia"
+date: 2026-06-17T20:00Z
+endDate: 2026-06-17T21:50Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/england-croatia/
+tags: ["England","Croatia","Dallas","Group L","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 67th game of the FIFA World Cup 2026 group stage between Group L competitors, England and Croatia.

--- a/src/_content/games/world-cup-2026/england-ghana.md
+++ b/src/_content/games/world-cup-2026/england-ghana.md
@@ -4,7 +4,7 @@ date: 2026-06-23T20:00Z
 endDate: 2026-06-23T21:50Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/england-ghana/
-tags: ["England","Ghana","Boston","Group L","Group stages","FIFA World Cup 2026"]
+tags: ["England","Ghana","Boston","Group L","Group stages","World Cup 2026"]
 tv: []
 ---
 The 69th game of the FIFA World Cup 2026 group stage between Group L competitors, England and Ghana.

--- a/src/_content/games/world-cup-2026/england-ghana.md
+++ b/src/_content/games/world-cup-2026/england-ghana.md
@@ -1,0 +1,10 @@
+---
+title: "England v Ghana"
+date: 2026-06-23T20:00Z
+endDate: 2026-06-23T21:50Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/england-ghana/
+tags: ["England","Ghana","Boston","Group L","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 69th game of the FIFA World Cup 2026 group stage between Group L competitors, England and Ghana.

--- a/src/_content/games/world-cup-2026/france-ic-playoff-2.md
+++ b/src/_content/games/world-cup-2026/france-ic-playoff-2.md
@@ -4,7 +4,7 @@ date: 2026-06-22T21:00Z
 endDate: 2026-06-22T22:50Z
 locationName: "Lincoln Financial Field, Philadelphia"
 path: /world-cup-2026/france-ic-playoff-2/
-tags: ["France","IC Playoff 2","Philadelphia","Group I","Group stages","FIFA World Cup 2026"]
+tags: ["France","IC Playoff 2","Philadelphia","Group I","Group stages","World Cup 2026"]
 tv: []
 ---
 The 51st game of the FIFA World Cup 2026 group stage between Group I competitors, France and IC Playoff 2.

--- a/src/_content/games/world-cup-2026/france-ic-playoff-2.md
+++ b/src/_content/games/world-cup-2026/france-ic-playoff-2.md
@@ -1,0 +1,10 @@
+---
+title: "France v IC Playoff 2"
+date: 2026-06-22T21:00Z
+endDate: 2026-06-22T22:50Z
+locationName: "Lincoln Financial Field, Philadelphia"
+path: /world-cup-2026/france-ic-playoff-2/
+tags: ["France","IC Playoff 2","Philadelphia","Group I","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 51st game of the FIFA World Cup 2026 group stage between Group I competitors, France and IC Playoff 2.

--- a/src/_content/games/world-cup-2026/france-senegal.md
+++ b/src/_content/games/world-cup-2026/france-senegal.md
@@ -4,7 +4,7 @@ date: 2026-06-16T19:00Z
 endDate: 2026-06-16T20:50Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/france-senegal/
-tags: ["France","Senegal","New York New Jersey","Group I","Group stages","FIFA World Cup 2026"]
+tags: ["France","Senegal","New York New Jersey","Group I","Group stages","World Cup 2026"]
 tv: []
 ---
 The 49th game of the FIFA World Cup 2026 group stage between Group I competitors, France and Senegal.

--- a/src/_content/games/world-cup-2026/france-senegal.md
+++ b/src/_content/games/world-cup-2026/france-senegal.md
@@ -1,0 +1,10 @@
+---
+title: "France v Senegal"
+date: 2026-06-16T19:00Z
+endDate: 2026-06-16T20:50Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/france-senegal/
+tags: ["France","Senegal","New York New Jersey","Group I","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 49th game of the FIFA World Cup 2026 group stage between Group I competitors, France and Senegal.

--- a/src/_content/games/world-cup-2026/germany-curacao.md
+++ b/src/_content/games/world-cup-2026/germany-curacao.md
@@ -4,7 +4,7 @@ date: 2026-06-14T17:00Z
 endDate: 2026-06-14T18:50Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/germany-curacao/
-tags: ["Germany","Curaçao","Houston","Group E","Group stages","FIFA World Cup 2026"]
+tags: ["Germany","Curaçao","Houston","Group E","Group stages","World Cup 2026"]
 tv: []
 ---
 The 25th game of the FIFA World Cup 2026 group stage between Group E competitors, Germany and Curaçao.

--- a/src/_content/games/world-cup-2026/germany-curacao.md
+++ b/src/_content/games/world-cup-2026/germany-curacao.md
@@ -1,0 +1,10 @@
+---
+title: "Germany v Curaçao"
+date: 2026-06-14T17:00Z
+endDate: 2026-06-14T18:50Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/germany-curacao/
+tags: ["Germany","Curaçao","Houston","Group E","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 25th game of the FIFA World Cup 2026 group stage between Group E competitors, Germany and Curaçao.

--- a/src/_content/games/world-cup-2026/germany-ivory-coast.md
+++ b/src/_content/games/world-cup-2026/germany-ivory-coast.md
@@ -1,0 +1,10 @@
+---
+title: "Germany v Ivory Coast"
+date: 2026-06-20T20:00Z
+endDate: 2026-06-20T21:50Z
+locationName: "BMO Field, Toronto"
+path: /world-cup-2026/germany-ivory-coast/
+tags: ["Germany","Ivory Coast","Toronto","Group E","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 27th game of the FIFA World Cup 2026 group stage between Group E competitors, Germany and Ivory Coast.

--- a/src/_content/games/world-cup-2026/germany-ivory-coast.md
+++ b/src/_content/games/world-cup-2026/germany-ivory-coast.md
@@ -4,7 +4,7 @@ date: 2026-06-20T20:00Z
 endDate: 2026-06-20T21:50Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/germany-ivory-coast/
-tags: ["Germany","Ivory Coast","Toronto","Group E","Group stages","FIFA World Cup 2026"]
+tags: ["Germany","Ivory Coast","Toronto","Group E","Group stages","World Cup 2026"]
 tv: []
 ---
 The 27th game of the FIFA World Cup 2026 group stage between Group E competitors, Germany and Ivory Coast.

--- a/src/_content/games/world-cup-2026/ghana-panama.md
+++ b/src/_content/games/world-cup-2026/ghana-panama.md
@@ -4,7 +4,7 @@ date: 2026-06-17T23:00Z
 endDate: 2026-06-18T00:50Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/ghana-panama/
-tags: ["Ghana","Panama","Toronto","Group L","Group stages","FIFA World Cup 2026"]
+tags: ["Ghana","Panama","Toronto","Group L","Group stages","World Cup 2026"]
 tv: []
 ---
 The 68th game of the FIFA World Cup 2026 group stage between Group L competitors, Ghana and Panama.

--- a/src/_content/games/world-cup-2026/ghana-panama.md
+++ b/src/_content/games/world-cup-2026/ghana-panama.md
@@ -1,0 +1,10 @@
+---
+title: "Ghana v Panama"
+date: 2026-06-17T23:00Z
+endDate: 2026-06-18T00:50Z
+locationName: "BMO Field, Toronto"
+path: /world-cup-2026/ghana-panama/
+tags: ["Ghana","Panama","Toronto","Group L","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 68th game of the FIFA World Cup 2026 group stage between Group L competitors, Ghana and Panama.

--- a/src/_content/games/world-cup-2026/haiti-scotland.md
+++ b/src/_content/games/world-cup-2026/haiti-scotland.md
@@ -4,7 +4,7 @@ date: 2026-06-14T01:00Z
 endDate: 2026-06-14T02:50Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/haiti-scotland/
-tags: ["Haiti","Scotland","Boston","Group C","Group stages","FIFA World Cup 2026"]
+tags: ["Haiti","Scotland","Boston","Group C","Group stages","World Cup 2026"]
 tv: []
 ---
 The 14th game of the FIFA World Cup 2026 group stage between Group C competitors, Haiti and Scotland.

--- a/src/_content/games/world-cup-2026/haiti-scotland.md
+++ b/src/_content/games/world-cup-2026/haiti-scotland.md
@@ -1,0 +1,10 @@
+---
+title: "Haiti v Scotland"
+date: 2026-06-14T01:00Z
+endDate: 2026-06-14T02:50Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/haiti-scotland/
+tags: ["Haiti","Scotland","Boston","Group C","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 14th game of the FIFA World Cup 2026 group stage between Group C competitors, Haiti and Scotland.

--- a/src/_content/games/world-cup-2026/ic-playoff-1-uzbekistan.md
+++ b/src/_content/games/world-cup-2026/ic-playoff-1-uzbekistan.md
@@ -1,0 +1,10 @@
+---
+title: "IC Playoff 1 v Uzbekistan"
+date: 2026-06-27T23:30Z
+endDate: 2026-06-28T01:20Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/ic-playoff-1-uzbekistan/
+tags: ["IC Playoff 1","Uzbekistan","Atlanta","Group K","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 66th game of the FIFA World Cup 2026 group stage between Group K competitors, IC Playoff 1 and Uzbekistan.

--- a/src/_content/games/world-cup-2026/ic-playoff-1-uzbekistan.md
+++ b/src/_content/games/world-cup-2026/ic-playoff-1-uzbekistan.md
@@ -4,7 +4,7 @@ date: 2026-06-27T23:30Z
 endDate: 2026-06-28T01:20Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/ic-playoff-1-uzbekistan/
-tags: ["IC Playoff 1","Uzbekistan","Atlanta","Group K","Group stages","FIFA World Cup 2026"]
+tags: ["IC Playoff 1","Uzbekistan","Atlanta","Group K","Group stages","World Cup 2026"]
 tv: []
 ---
 The 66th game of the FIFA World Cup 2026 group stage between Group K competitors, IC Playoff 1 and Uzbekistan.

--- a/src/_content/games/world-cup-2026/ic-playoff-2-norway.md
+++ b/src/_content/games/world-cup-2026/ic-playoff-2-norway.md
@@ -4,7 +4,7 @@ date: 2026-06-16T22:00Z
 endDate: 2026-06-16T23:50Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/ic-playoff-2-norway/
-tags: ["IC Playoff 2","Norway","Boston","Group I","Group stages","FIFA World Cup 2026"]
+tags: ["IC Playoff 2","Norway","Boston","Group I","Group stages","World Cup 2026"]
 tv: []
 ---
 The 50th game of the FIFA World Cup 2026 group stage between Group I competitors, IC Playoff 2 and Norway.

--- a/src/_content/games/world-cup-2026/ic-playoff-2-norway.md
+++ b/src/_content/games/world-cup-2026/ic-playoff-2-norway.md
@@ -1,0 +1,10 @@
+---
+title: "IC Playoff 2 v Norway"
+date: 2026-06-16T22:00Z
+endDate: 2026-06-16T23:50Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/ic-playoff-2-norway/
+tags: ["IC Playoff 2","Norway","Boston","Group I","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 50th game of the FIFA World Cup 2026 group stage between Group I competitors, IC Playoff 2 and Norway.

--- a/src/_content/games/world-cup-2026/iran-new-zealand.md
+++ b/src/_content/games/world-cup-2026/iran-new-zealand.md
@@ -1,0 +1,10 @@
+---
+title: "Iran v New Zealand"
+date: 2026-06-16T01:00Z
+endDate: 2026-06-16T02:50Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/iran-new-zealand/
+tags: ["Iran","New Zealand","Los Angeles","Group G","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 38th game of the FIFA World Cup 2026 group stage between Group G competitors, Iran and New Zealand.

--- a/src/_content/games/world-cup-2026/iran-new-zealand.md
+++ b/src/_content/games/world-cup-2026/iran-new-zealand.md
@@ -4,7 +4,7 @@ date: 2026-06-16T01:00Z
 endDate: 2026-06-16T02:50Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/iran-new-zealand/
-tags: ["Iran","New Zealand","Los Angeles","Group G","Group stages","FIFA World Cup 2026"]
+tags: ["Iran","New Zealand","Los Angeles","Group G","Group stages","World Cup 2026"]
 tv: []
 ---
 The 38th game of the FIFA World Cup 2026 group stage between Group G competitors, Iran and New Zealand.

--- a/src/_content/games/world-cup-2026/ivory-coast-ecuador.md
+++ b/src/_content/games/world-cup-2026/ivory-coast-ecuador.md
@@ -1,0 +1,10 @@
+---
+title: "Ivory Coast v Ecuador"
+date: 2026-06-14T23:00Z
+endDate: 2026-06-15T00:50Z
+locationName: "Lincoln Financial Field, Philadelphia"
+path: /world-cup-2026/ivory-coast-ecuador/
+tags: ["Ivory Coast","Ecuador","Philadelphia","Group E","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 26th game of the FIFA World Cup 2026 group stage between Group E competitors, Ivory Coast and Ecuador.

--- a/src/_content/games/world-cup-2026/ivory-coast-ecuador.md
+++ b/src/_content/games/world-cup-2026/ivory-coast-ecuador.md
@@ -4,7 +4,7 @@ date: 2026-06-14T23:00Z
 endDate: 2026-06-15T00:50Z
 locationName: "Lincoln Financial Field, Philadelphia"
 path: /world-cup-2026/ivory-coast-ecuador/
-tags: ["Ivory Coast","Ecuador","Philadelphia","Group E","Group stages","FIFA World Cup 2026"]
+tags: ["Ivory Coast","Ecuador","Philadelphia","Group E","Group stages","World Cup 2026"]
 tv: []
 ---
 The 26th game of the FIFA World Cup 2026 group stage between Group E competitors, Ivory Coast and Ecuador.

--- a/src/_content/games/world-cup-2026/japan-uefa-playoff-b.md
+++ b/src/_content/games/world-cup-2026/japan-uefa-playoff-b.md
@@ -1,0 +1,10 @@
+---
+title: "Japan v UEFA Playoff B"
+date: 2026-06-25T23:00Z
+endDate: 2026-06-26T00:50Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/japan-uefa-playoff-b/
+tags: ["Japan","UEFA Playoff B","Dallas","Group F","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 35th game of the FIFA World Cup 2026 group stage between Group F competitors, Japan and UEFA Playoff B.

--- a/src/_content/games/world-cup-2026/japan-uefa-playoff-b.md
+++ b/src/_content/games/world-cup-2026/japan-uefa-playoff-b.md
@@ -4,7 +4,7 @@ date: 2026-06-25T23:00Z
 endDate: 2026-06-26T00:50Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/japan-uefa-playoff-b/
-tags: ["Japan","UEFA Playoff B","Dallas","Group F","Group stages","FIFA World Cup 2026"]
+tags: ["Japan","UEFA Playoff B","Dallas","Group F","Group stages","World Cup 2026"]
 tv: []
 ---
 The 35th game of the FIFA World Cup 2026 group stage between Group F competitors, Japan and UEFA Playoff B.

--- a/src/_content/games/world-cup-2026/jordan-algeria.md
+++ b/src/_content/games/world-cup-2026/jordan-algeria.md
@@ -4,7 +4,7 @@ date: 2026-06-23T03:00Z
 endDate: 2026-06-23T04:50Z
 locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/jordan-algeria/
-tags: ["Jordan","Algeria","San Francisco","Group J","Group stages","FIFA World Cup 2026"]
+tags: ["Jordan","Algeria","San Francisco","Group J","Group stages","World Cup 2026"]
 tv: []
 ---
 The 58th game of the FIFA World Cup 2026 group stage between Group J competitors, Jordan and Algeria.

--- a/src/_content/games/world-cup-2026/jordan-algeria.md
+++ b/src/_content/games/world-cup-2026/jordan-algeria.md
@@ -1,0 +1,10 @@
+---
+title: "Jordan v Algeria"
+date: 2026-06-23T03:00Z
+endDate: 2026-06-23T04:50Z
+locationName: "Levi's Stadium, San Francisco"
+path: /world-cup-2026/jordan-algeria/
+tags: ["Jordan","Algeria","San Francisco","Group J","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 58th game of the FIFA World Cup 2026 group stage between Group J competitors, Jordan and Algeria.

--- a/src/_content/games/world-cup-2026/jordan-argentina.md
+++ b/src/_content/games/world-cup-2026/jordan-argentina.md
@@ -4,7 +4,7 @@ date: 2026-06-28T02:00Z
 endDate: 2026-06-28T03:50Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/jordan-argentina/
-tags: ["Jordan","Argentina","Dallas","Group J","Group stages","FIFA World Cup 2026"]
+tags: ["Jordan","Argentina","Dallas","Group J","Group stages","World Cup 2026"]
 tv: []
 ---
 The 60th game of the FIFA World Cup 2026 group stage between Group J competitors, Jordan and Argentina.

--- a/src/_content/games/world-cup-2026/jordan-argentina.md
+++ b/src/_content/games/world-cup-2026/jordan-argentina.md
@@ -1,0 +1,10 @@
+---
+title: "Jordan v Argentina"
+date: 2026-06-28T02:00Z
+endDate: 2026-06-28T03:50Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/jordan-argentina/
+tags: ["Jordan","Argentina","Dallas","Group J","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 60th game of the FIFA World Cup 2026 group stage between Group J competitors, Jordan and Argentina.

--- a/src/_content/games/world-cup-2026/mexico-south-africa.md
+++ b/src/_content/games/world-cup-2026/mexico-south-africa.md
@@ -1,0 +1,10 @@
+---
+title: "Mexico v South Africa"
+date: 2026-06-11T20:00Z
+endDate: 2026-06-11T21:50Z
+locationName: "Estadio Azteca, Mexico City"
+path: /world-cup-2026/mexico-south-africa/
+tags: ["Mexico","South Africa","Mexico City","Group A","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 1st game of the FIFA World Cup 2026 group stage between Group A competitors, Mexico and South Africa.

--- a/src/_content/games/world-cup-2026/mexico-south-africa.md
+++ b/src/_content/games/world-cup-2026/mexico-south-africa.md
@@ -4,7 +4,7 @@ date: 2026-06-11T20:00Z
 endDate: 2026-06-11T21:50Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/mexico-south-africa/
-tags: ["Mexico","South Africa","Mexico City","Group A","Group stages","FIFA World Cup 2026"]
+tags: ["Mexico","South Africa","Mexico City","Group A","Group stages","World Cup 2026"]
 tv: []
 ---
 The 1st game of the FIFA World Cup 2026 group stage between Group A competitors, Mexico and South Africa.

--- a/src/_content/games/world-cup-2026/mexico-south-korea.md
+++ b/src/_content/games/world-cup-2026/mexico-south-korea.md
@@ -4,7 +4,7 @@ date: 2026-06-19T02:00Z
 endDate: 2026-06-19T03:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/mexico-south-korea/
-tags: ["Mexico","South Korea","Guadalajara","Group A","Group stages","FIFA World Cup 2026"]
+tags: ["Mexico","South Korea","Guadalajara","Group A","Group stages","World Cup 2026"]
 tv: []
 ---
 The 4th game of the FIFA World Cup 2026 group stage between Group A competitors, Mexico and South Korea.

--- a/src/_content/games/world-cup-2026/mexico-south-korea.md
+++ b/src/_content/games/world-cup-2026/mexico-south-korea.md
@@ -1,0 +1,10 @@
+---
+title: "Mexico v South Korea"
+date: 2026-06-19T02:00Z
+endDate: 2026-06-19T03:50Z
+locationName: "Estadio Akron, Guadalajara"
+path: /world-cup-2026/mexico-south-korea/
+tags: ["Mexico","South Korea","Guadalajara","Group A","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 4th game of the FIFA World Cup 2026 group stage between Group A competitors, Mexico and South Korea.

--- a/src/_content/games/world-cup-2026/mexico-uefa-playoff-d.md
+++ b/src/_content/games/world-cup-2026/mexico-uefa-playoff-d.md
@@ -1,0 +1,10 @@
+---
+title: "Mexico v UEFA Playoff D"
+date: 2026-06-25T02:00Z
+endDate: 2026-06-25T03:50Z
+locationName: "Estadio Azteca, Mexico City"
+path: /world-cup-2026/mexico-uefa-playoff-d/
+tags: ["Mexico","UEFA Playoff D","Mexico City","Group A","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 5th game of the FIFA World Cup 2026 group stage between Group A competitors, Mexico and UEFA Playoff D.

--- a/src/_content/games/world-cup-2026/mexico-uefa-playoff-d.md
+++ b/src/_content/games/world-cup-2026/mexico-uefa-playoff-d.md
@@ -4,7 +4,7 @@ date: 2026-06-25T02:00Z
 endDate: 2026-06-25T03:50Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/mexico-uefa-playoff-d/
-tags: ["Mexico","UEFA Playoff D","Mexico City","Group A","Group stages","FIFA World Cup 2026"]
+tags: ["Mexico","UEFA Playoff D","Mexico City","Group A","Group stages","World Cup 2026"]
 tv: []
 ---
 The 5th game of the FIFA World Cup 2026 group stage between Group A competitors, Mexico and UEFA Playoff D.

--- a/src/_content/games/world-cup-2026/morocco-haiti.md
+++ b/src/_content/games/world-cup-2026/morocco-haiti.md
@@ -4,7 +4,7 @@ date: 2026-06-24T22:00Z
 endDate: 2026-06-24T23:50Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/morocco-haiti/
-tags: ["Morocco","Haiti","Atlanta","Group C","Group stages","FIFA World Cup 2026"]
+tags: ["Morocco","Haiti","Atlanta","Group C","Group stages","World Cup 2026"]
 tv: []
 ---
 The 18th game of the FIFA World Cup 2026 group stage between Group C competitors, Morocco and Haiti.

--- a/src/_content/games/world-cup-2026/morocco-haiti.md
+++ b/src/_content/games/world-cup-2026/morocco-haiti.md
@@ -1,0 +1,10 @@
+---
+title: "Morocco v Haiti"
+date: 2026-06-24T22:00Z
+endDate: 2026-06-24T23:50Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/morocco-haiti/
+tags: ["Morocco","Haiti","Atlanta","Group C","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 18th game of the FIFA World Cup 2026 group stage between Group C competitors, Morocco and Haiti.

--- a/src/_content/games/world-cup-2026/netherlands-japan.md
+++ b/src/_content/games/world-cup-2026/netherlands-japan.md
@@ -1,0 +1,10 @@
+---
+title: "Netherlands v Japan"
+date: 2026-06-14T20:00Z
+endDate: 2026-06-14T21:50Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/netherlands-japan/
+tags: ["Netherlands","Japan","Dallas","Group F","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 31st game of the FIFA World Cup 2026 group stage between Group F competitors, Netherlands and Japan.

--- a/src/_content/games/world-cup-2026/netherlands-japan.md
+++ b/src/_content/games/world-cup-2026/netherlands-japan.md
@@ -4,7 +4,7 @@ date: 2026-06-14T20:00Z
 endDate: 2026-06-14T21:50Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/netherlands-japan/
-tags: ["Netherlands","Japan","Dallas","Group F","Group stages","FIFA World Cup 2026"]
+tags: ["Netherlands","Japan","Dallas","Group F","Group stages","World Cup 2026"]
 tv: []
 ---
 The 31st game of the FIFA World Cup 2026 group stage between Group F competitors, Netherlands and Japan.

--- a/src/_content/games/world-cup-2026/netherlands-uefa-playoff-b.md
+++ b/src/_content/games/world-cup-2026/netherlands-uefa-playoff-b.md
@@ -1,0 +1,10 @@
+---
+title: "Netherlands v UEFA Playoff B"
+date: 2026-06-20T17:00Z
+endDate: 2026-06-20T18:50Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/netherlands-uefa-playoff-b/
+tags: ["Netherlands","UEFA Playoff B","Houston","Group F","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 33rd game of the FIFA World Cup 2026 group stage between Group F competitors, Netherlands and UEFA Playoff B.

--- a/src/_content/games/world-cup-2026/netherlands-uefa-playoff-b.md
+++ b/src/_content/games/world-cup-2026/netherlands-uefa-playoff-b.md
@@ -4,7 +4,7 @@ date: 2026-06-20T17:00Z
 endDate: 2026-06-20T18:50Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/netherlands-uefa-playoff-b/
-tags: ["Netherlands","UEFA Playoff B","Houston","Group F","Group stages","FIFA World Cup 2026"]
+tags: ["Netherlands","UEFA Playoff B","Houston","Group F","Group stages","World Cup 2026"]
 tv: []
 ---
 The 33rd game of the FIFA World Cup 2026 group stage between Group F competitors, Netherlands and UEFA Playoff B.

--- a/src/_content/games/world-cup-2026/new-zealand-belgium.md
+++ b/src/_content/games/world-cup-2026/new-zealand-belgium.md
@@ -1,0 +1,10 @@
+---
+title: "New Zealand v Belgium"
+date: 2026-06-27T03:00Z
+endDate: 2026-06-27T04:50Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/new-zealand-belgium/
+tags: ["New Zealand","Belgium","Vancouver","Group G","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 42nd game of the FIFA World Cup 2026 group stage between Group G competitors, New Zealand and Belgium.

--- a/src/_content/games/world-cup-2026/new-zealand-belgium.md
+++ b/src/_content/games/world-cup-2026/new-zealand-belgium.md
@@ -4,7 +4,7 @@ date: 2026-06-27T03:00Z
 endDate: 2026-06-27T04:50Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/new-zealand-belgium/
-tags: ["New Zealand","Belgium","Vancouver","Group G","Group stages","FIFA World Cup 2026"]
+tags: ["New Zealand","Belgium","Vancouver","Group G","Group stages","World Cup 2026"]
 tv: []
 ---
 The 42nd game of the FIFA World Cup 2026 group stage between Group G competitors, New Zealand and Belgium.

--- a/src/_content/games/world-cup-2026/new-zealand-egypt.md
+++ b/src/_content/games/world-cup-2026/new-zealand-egypt.md
@@ -4,7 +4,7 @@ date: 2026-06-22T01:00Z
 endDate: 2026-06-22T02:50Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/new-zealand-egypt/
-tags: ["New Zealand","Egypt","Vancouver","Group G","Group stages","FIFA World Cup 2026"]
+tags: ["New Zealand","Egypt","Vancouver","Group G","Group stages","World Cup 2026"]
 tv: []
 ---
 The 40th game of the FIFA World Cup 2026 group stage between Group G competitors, New Zealand and Egypt.

--- a/src/_content/games/world-cup-2026/new-zealand-egypt.md
+++ b/src/_content/games/world-cup-2026/new-zealand-egypt.md
@@ -1,0 +1,10 @@
+---
+title: "New Zealand v Egypt"
+date: 2026-06-22T01:00Z
+endDate: 2026-06-22T02:50Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/new-zealand-egypt/
+tags: ["New Zealand","Egypt","Vancouver","Group G","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 40th game of the FIFA World Cup 2026 group stage between Group G competitors, New Zealand and Egypt.

--- a/src/_content/games/world-cup-2026/norway-france.md
+++ b/src/_content/games/world-cup-2026/norway-france.md
@@ -1,0 +1,10 @@
+---
+title: "Norway v France"
+date: 2026-06-26T19:00Z
+endDate: 2026-06-26T20:50Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/norway-france/
+tags: ["Norway","France","Boston","Group I","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 53rd game of the FIFA World Cup 2026 group stage between Group I competitors, Norway and France.

--- a/src/_content/games/world-cup-2026/norway-france.md
+++ b/src/_content/games/world-cup-2026/norway-france.md
@@ -4,7 +4,7 @@ date: 2026-06-26T19:00Z
 endDate: 2026-06-26T20:50Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/norway-france/
-tags: ["Norway","France","Boston","Group I","Group stages","FIFA World Cup 2026"]
+tags: ["Norway","France","Boston","Group I","Group stages","World Cup 2026"]
 tv: []
 ---
 The 53rd game of the FIFA World Cup 2026 group stage between Group I competitors, Norway and France.

--- a/src/_content/games/world-cup-2026/norway-senegal.md
+++ b/src/_content/games/world-cup-2026/norway-senegal.md
@@ -1,0 +1,10 @@
+---
+title: "Norway v Senegal"
+date: 2026-06-23T00:00Z
+endDate: 2026-06-23T01:50Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/norway-senegal/
+tags: ["Norway","Senegal","New York New Jersey","Group I","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 52nd game of the FIFA World Cup 2026 group stage between Group I competitors, Norway and Senegal.

--- a/src/_content/games/world-cup-2026/norway-senegal.md
+++ b/src/_content/games/world-cup-2026/norway-senegal.md
@@ -4,7 +4,7 @@ date: 2026-06-23T00:00Z
 endDate: 2026-06-23T01:50Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/norway-senegal/
-tags: ["Norway","Senegal","New York New Jersey","Group I","Group stages","FIFA World Cup 2026"]
+tags: ["Norway","Senegal","New York New Jersey","Group I","Group stages","World Cup 2026"]
 tv: []
 ---
 The 52nd game of the FIFA World Cup 2026 group stage between Group I competitors, Norway and Senegal.

--- a/src/_content/games/world-cup-2026/panama-croatia.md
+++ b/src/_content/games/world-cup-2026/panama-croatia.md
@@ -1,0 +1,10 @@
+---
+title: "Panama v Croatia"
+date: 2026-06-23T23:00Z
+endDate: 2026-06-24T00:50Z
+locationName: "BMO Field, Toronto"
+path: /world-cup-2026/panama-croatia/
+tags: ["Panama","Croatia","Toronto","Group L","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 70th game of the FIFA World Cup 2026 group stage between Group L competitors, Panama and Croatia.

--- a/src/_content/games/world-cup-2026/panama-croatia.md
+++ b/src/_content/games/world-cup-2026/panama-croatia.md
@@ -4,7 +4,7 @@ date: 2026-06-23T23:00Z
 endDate: 2026-06-24T00:50Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/panama-croatia/
-tags: ["Panama","Croatia","Toronto","Group L","Group stages","FIFA World Cup 2026"]
+tags: ["Panama","Croatia","Toronto","Group L","Group stages","World Cup 2026"]
 tv: []
 ---
 The 70th game of the FIFA World Cup 2026 group stage between Group L competitors, Panama and Croatia.

--- a/src/_content/games/world-cup-2026/panama-england.md
+++ b/src/_content/games/world-cup-2026/panama-england.md
@@ -4,7 +4,7 @@ date: 2026-06-27T21:00Z
 endDate: 2026-06-27T22:50Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/panama-england/
-tags: ["Panama","England","New York New Jersey","Group L","Group stages","FIFA World Cup 2026"]
+tags: ["Panama","England","New York New Jersey","Group L","Group stages","World Cup 2026"]
 tv: []
 ---
 The 71st game of the FIFA World Cup 2026 group stage between Group L competitors, Panama and England.

--- a/src/_content/games/world-cup-2026/panama-england.md
+++ b/src/_content/games/world-cup-2026/panama-england.md
@@ -1,0 +1,10 @@
+---
+title: "Panama v England"
+date: 2026-06-27T21:00Z
+endDate: 2026-06-27T22:50Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/panama-england/
+tags: ["Panama","England","New York New Jersey","Group L","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 71st game of the FIFA World Cup 2026 group stage between Group L competitors, Panama and England.

--- a/src/_content/games/world-cup-2026/paraguay-australia.md
+++ b/src/_content/games/world-cup-2026/paraguay-australia.md
@@ -4,7 +4,7 @@ date: 2026-06-26T02:00Z
 endDate: 2026-06-26T03:50Z
 locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/paraguay-australia/
-tags: ["Paraguay","Australia","San Francisco","Group D","Group stages","FIFA World Cup 2026"]
+tags: ["Paraguay","Australia","San Francisco","Group D","Group stages","World Cup 2026"]
 tv: []
 ---
 The 24th game of the FIFA World Cup 2026 group stage between Group D competitors, Paraguay and Australia.

--- a/src/_content/games/world-cup-2026/paraguay-australia.md
+++ b/src/_content/games/world-cup-2026/paraguay-australia.md
@@ -1,0 +1,10 @@
+---
+title: "Paraguay v Australia"
+date: 2026-06-26T02:00Z
+endDate: 2026-06-26T03:50Z
+locationName: "Levi's Stadium, San Francisco"
+path: /world-cup-2026/paraguay-australia/
+tags: ["Paraguay","Australia","San Francisco","Group D","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 24th game of the FIFA World Cup 2026 group stage between Group D competitors, Paraguay and Australia.

--- a/src/_content/games/world-cup-2026/portugal-ic-playoff-1.md
+++ b/src/_content/games/world-cup-2026/portugal-ic-playoff-1.md
@@ -1,0 +1,10 @@
+---
+title: "Portugal v IC Playoff 1"
+date: 2026-06-17T17:00Z
+endDate: 2026-06-17T18:50Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/portugal-ic-playoff-1/
+tags: ["Portugal","IC Playoff 1","Houston","Group K","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 61st game of the FIFA World Cup 2026 group stage between Group K competitors, Portugal and IC Playoff 1.

--- a/src/_content/games/world-cup-2026/portugal-ic-playoff-1.md
+++ b/src/_content/games/world-cup-2026/portugal-ic-playoff-1.md
@@ -4,7 +4,7 @@ date: 2026-06-17T17:00Z
 endDate: 2026-06-17T18:50Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/portugal-ic-playoff-1/
-tags: ["Portugal","IC Playoff 1","Houston","Group K","Group stages","FIFA World Cup 2026"]
+tags: ["Portugal","IC Playoff 1","Houston","Group K","Group stages","World Cup 2026"]
 tv: []
 ---
 The 61st game of the FIFA World Cup 2026 group stage between Group K competitors, Portugal and IC Playoff 1.

--- a/src/_content/games/world-cup-2026/portugal-uzbekistan.md
+++ b/src/_content/games/world-cup-2026/portugal-uzbekistan.md
@@ -1,0 +1,10 @@
+---
+title: "Portugal v Uzbekistan"
+date: 2026-06-23T17:00Z
+endDate: 2026-06-23T18:50Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/portugal-uzbekistan/
+tags: ["Portugal","Uzbekistan","Houston","Group K","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 63rd game of the FIFA World Cup 2026 group stage between Group K competitors, Portugal and Uzbekistan.

--- a/src/_content/games/world-cup-2026/portugal-uzbekistan.md
+++ b/src/_content/games/world-cup-2026/portugal-uzbekistan.md
@@ -4,7 +4,7 @@ date: 2026-06-23T17:00Z
 endDate: 2026-06-23T18:50Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/portugal-uzbekistan/
-tags: ["Portugal","Uzbekistan","Houston","Group K","Group stages","FIFA World Cup 2026"]
+tags: ["Portugal","Uzbekistan","Houston","Group K","Group stages","World Cup 2026"]
 tv: []
 ---
 The 63rd game of the FIFA World Cup 2026 group stage between Group K competitors, Portugal and Uzbekistan.

--- a/src/_content/games/world-cup-2026/qatar-switzerland.md
+++ b/src/_content/games/world-cup-2026/qatar-switzerland.md
@@ -1,0 +1,10 @@
+---
+title: "Qatar v Switzerland"
+date: 2026-06-13T19:00Z
+endDate: 2026-06-13T20:50Z
+locationName: "Levi's Stadium, San Francisco"
+path: /world-cup-2026/qatar-switzerland/
+tags: ["Qatar","Switzerland","San Francisco","Group B","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 8th game of the FIFA World Cup 2026 group stage between Group B competitors, Qatar and Switzerland.

--- a/src/_content/games/world-cup-2026/qatar-switzerland.md
+++ b/src/_content/games/world-cup-2026/qatar-switzerland.md
@@ -4,7 +4,7 @@ date: 2026-06-13T19:00Z
 endDate: 2026-06-13T20:50Z
 locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/qatar-switzerland/
-tags: ["Qatar","Switzerland","San Francisco","Group B","Group stages","FIFA World Cup 2026"]
+tags: ["Qatar","Switzerland","San Francisco","Group B","Group stages","World Cup 2026"]
 tv: []
 ---
 The 8th game of the FIFA World Cup 2026 group stage between Group B competitors, Qatar and Switzerland.

--- a/src/_content/games/world-cup-2026/saudi-arabia-uruguay.md
+++ b/src/_content/games/world-cup-2026/saudi-arabia-uruguay.md
@@ -4,7 +4,7 @@ date: 2026-06-15T22:00Z
 endDate: 2026-06-15T23:50Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/saudi-arabia-uruguay/
-tags: ["Saudi Arabia","Uruguay","Miami","Group H","Group stages","FIFA World Cup 2026"]
+tags: ["Saudi Arabia","Uruguay","Miami","Group H","Group stages","World Cup 2026"]
 tv: []
 ---
 The 44th game of the FIFA World Cup 2026 group stage between Group H competitors, Saudi Arabia and Uruguay.

--- a/src/_content/games/world-cup-2026/saudi-arabia-uruguay.md
+++ b/src/_content/games/world-cup-2026/saudi-arabia-uruguay.md
@@ -1,0 +1,10 @@
+---
+title: "Saudi Arabia v Uruguay"
+date: 2026-06-15T22:00Z
+endDate: 2026-06-15T23:50Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/saudi-arabia-uruguay/
+tags: ["Saudi Arabia","Uruguay","Miami","Group H","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 44th game of the FIFA World Cup 2026 group stage between Group H competitors, Saudi Arabia and Uruguay.

--- a/src/_content/games/world-cup-2026/scotland-brazil.md
+++ b/src/_content/games/world-cup-2026/scotland-brazil.md
@@ -4,7 +4,7 @@ date: 2026-06-24T22:00Z
 endDate: 2026-06-24T23:50Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/scotland-brazil/
-tags: ["Scotland","Brazil","Miami","Group C","Group stages","FIFA World Cup 2026"]
+tags: ["Scotland","Brazil","Miami","Group C","Group stages","World Cup 2026"]
 tv: []
 ---
 The 17th game of the FIFA World Cup 2026 group stage between Group C competitors, Scotland and Brazil.

--- a/src/_content/games/world-cup-2026/scotland-brazil.md
+++ b/src/_content/games/world-cup-2026/scotland-brazil.md
@@ -1,0 +1,10 @@
+---
+title: "Scotland v Brazil"
+date: 2026-06-24T22:00Z
+endDate: 2026-06-24T23:50Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/scotland-brazil/
+tags: ["Scotland","Brazil","Miami","Group C","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 17th game of the FIFA World Cup 2026 group stage between Group C competitors, Scotland and Brazil.

--- a/src/_content/games/world-cup-2026/scotland-morocco.md
+++ b/src/_content/games/world-cup-2026/scotland-morocco.md
@@ -4,7 +4,7 @@ date: 2026-06-19T22:00Z
 endDate: 2026-06-19T23:50Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/scotland-morocco/
-tags: ["Scotland","Morocco","Boston","Group C","Group stages","FIFA World Cup 2026"]
+tags: ["Scotland","Morocco","Boston","Group C","Group stages","World Cup 2026"]
 tv: []
 ---
 The 15th game of the FIFA World Cup 2026 group stage between Group C competitors, Scotland and Morocco.

--- a/src/_content/games/world-cup-2026/scotland-morocco.md
+++ b/src/_content/games/world-cup-2026/scotland-morocco.md
@@ -1,0 +1,10 @@
+---
+title: "Scotland v Morocco"
+date: 2026-06-19T22:00Z
+endDate: 2026-06-19T23:50Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/scotland-morocco/
+tags: ["Scotland","Morocco","Boston","Group C","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 15th game of the FIFA World Cup 2026 group stage between Group C competitors, Scotland and Morocco.

--- a/src/_content/games/world-cup-2026/senegal-ic-playoff-2.md
+++ b/src/_content/games/world-cup-2026/senegal-ic-playoff-2.md
@@ -4,7 +4,7 @@ date: 2026-06-26T19:00Z
 endDate: 2026-06-26T20:50Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/senegal-ic-playoff-2/
-tags: ["Senegal","IC Playoff 2","Toronto","Group I","Group stages","FIFA World Cup 2026"]
+tags: ["Senegal","IC Playoff 2","Toronto","Group I","Group stages","World Cup 2026"]
 tv: []
 ---
 The 54th game of the FIFA World Cup 2026 group stage between Group I competitors, Senegal and IC Playoff 2.

--- a/src/_content/games/world-cup-2026/senegal-ic-playoff-2.md
+++ b/src/_content/games/world-cup-2026/senegal-ic-playoff-2.md
@@ -1,0 +1,10 @@
+---
+title: "Senegal v IC Playoff 2"
+date: 2026-06-26T19:00Z
+endDate: 2026-06-26T20:50Z
+locationName: "BMO Field, Toronto"
+path: /world-cup-2026/senegal-ic-playoff-2/
+tags: ["Senegal","IC Playoff 2","Toronto","Group I","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 54th game of the FIFA World Cup 2026 group stage between Group I competitors, Senegal and IC Playoff 2.

--- a/src/_content/games/world-cup-2026/south-africa-south-korea.md
+++ b/src/_content/games/world-cup-2026/south-africa-south-korea.md
@@ -1,0 +1,10 @@
+---
+title: "South Africa v South Korea"
+date: 2026-06-25T02:00Z
+endDate: 2026-06-25T03:50Z
+locationName: "Estadio BBVA, Monterrey"
+path: /world-cup-2026/south-africa-south-korea/
+tags: ["South Africa","South Korea","Monterrey","Group A","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 6th game of the FIFA World Cup 2026 group stage between Group A competitors, South Africa and South Korea.

--- a/src/_content/games/world-cup-2026/south-africa-south-korea.md
+++ b/src/_content/games/world-cup-2026/south-africa-south-korea.md
@@ -4,7 +4,7 @@ date: 2026-06-25T02:00Z
 endDate: 2026-06-25T03:50Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/south-africa-south-korea/
-tags: ["South Africa","South Korea","Monterrey","Group A","Group stages","FIFA World Cup 2026"]
+tags: ["South Africa","South Korea","Monterrey","Group A","Group stages","World Cup 2026"]
 tv: []
 ---
 The 6th game of the FIFA World Cup 2026 group stage between Group A competitors, South Africa and South Korea.

--- a/src/_content/games/world-cup-2026/south-korea-uefa-playoff-d.md
+++ b/src/_content/games/world-cup-2026/south-korea-uefa-playoff-d.md
@@ -4,7 +4,7 @@ date: 2026-06-12T03:00Z
 endDate: 2026-06-12T04:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/south-korea-uefa-playoff-d/
-tags: ["South Korea","UEFA Playoff D","Guadalajara","Group A","Group stages","FIFA World Cup 2026"]
+tags: ["South Korea","UEFA Playoff D","Guadalajara","Group A","Group stages","World Cup 2026"]
 tv: []
 ---
 The 2nd game of the FIFA World Cup 2026 group stage between Group A competitors, South Korea and UEFA Playoff D.

--- a/src/_content/games/world-cup-2026/south-korea-uefa-playoff-d.md
+++ b/src/_content/games/world-cup-2026/south-korea-uefa-playoff-d.md
@@ -1,0 +1,10 @@
+---
+title: "South Korea v UEFA Playoff D"
+date: 2026-06-12T03:00Z
+endDate: 2026-06-12T04:50Z
+locationName: "Estadio Akron, Guadalajara"
+path: /world-cup-2026/south-korea-uefa-playoff-d/
+tags: ["South Korea","UEFA Playoff D","Guadalajara","Group A","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 2nd game of the FIFA World Cup 2026 group stage between Group A competitors, South Korea and UEFA Playoff D.

--- a/src/_content/games/world-cup-2026/spain-cape-verde.md
+++ b/src/_content/games/world-cup-2026/spain-cape-verde.md
@@ -4,7 +4,7 @@ date: 2026-06-15T16:00Z
 endDate: 2026-06-15T17:50Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/spain-cape-verde/
-tags: ["Spain","Cape Verde","Atlanta","Group H","Group stages","FIFA World Cup 2026"]
+tags: ["Spain","Cape Verde","Atlanta","Group H","Group stages","World Cup 2026"]
 tv: []
 ---
 The 43rd game of the FIFA World Cup 2026 group stage between Group H competitors, Spain and Cape Verde.

--- a/src/_content/games/world-cup-2026/spain-cape-verde.md
+++ b/src/_content/games/world-cup-2026/spain-cape-verde.md
@@ -1,0 +1,10 @@
+---
+title: "Spain v Cape Verde"
+date: 2026-06-15T16:00Z
+endDate: 2026-06-15T17:50Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/spain-cape-verde/
+tags: ["Spain","Cape Verde","Atlanta","Group H","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 43rd game of the FIFA World Cup 2026 group stage between Group H competitors, Spain and Cape Verde.

--- a/src/_content/games/world-cup-2026/spain-saudi-arabia.md
+++ b/src/_content/games/world-cup-2026/spain-saudi-arabia.md
@@ -1,0 +1,10 @@
+---
+title: "Spain v Saudi Arabia"
+date: 2026-06-21T16:00Z
+endDate: 2026-06-21T17:50Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/spain-saudi-arabia/
+tags: ["Spain","Saudi Arabia","Atlanta","Group H","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 45th game of the FIFA World Cup 2026 group stage between Group H competitors, Spain and Saudi Arabia.

--- a/src/_content/games/world-cup-2026/spain-saudi-arabia.md
+++ b/src/_content/games/world-cup-2026/spain-saudi-arabia.md
@@ -4,7 +4,7 @@ date: 2026-06-21T16:00Z
 endDate: 2026-06-21T17:50Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/spain-saudi-arabia/
-tags: ["Spain","Saudi Arabia","Atlanta","Group H","Group stages","FIFA World Cup 2026"]
+tags: ["Spain","Saudi Arabia","Atlanta","Group H","Group stages","World Cup 2026"]
 tv: []
 ---
 The 45th game of the FIFA World Cup 2026 group stage between Group H competitors, Spain and Saudi Arabia.

--- a/src/_content/games/world-cup-2026/switzerland-canada.md
+++ b/src/_content/games/world-cup-2026/switzerland-canada.md
@@ -1,0 +1,10 @@
+---
+title: "Switzerland v Canada"
+date: 2026-06-24T19:00Z
+endDate: 2026-06-24T20:50Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/switzerland-canada/
+tags: ["Switzerland","Canada","Vancouver","Group B","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 11th game of the FIFA World Cup 2026 group stage between Group B competitors, Switzerland and Canada.

--- a/src/_content/games/world-cup-2026/switzerland-canada.md
+++ b/src/_content/games/world-cup-2026/switzerland-canada.md
@@ -4,7 +4,7 @@ date: 2026-06-24T19:00Z
 endDate: 2026-06-24T20:50Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/switzerland-canada/
-tags: ["Switzerland","Canada","Vancouver","Group B","Group stages","FIFA World Cup 2026"]
+tags: ["Switzerland","Canada","Vancouver","Group B","Group stages","World Cup 2026"]
 tv: []
 ---
 The 11th game of the FIFA World Cup 2026 group stage between Group B competitors, Switzerland and Canada.

--- a/src/_content/games/world-cup-2026/switzerland-uefa-playoff-a.md
+++ b/src/_content/games/world-cup-2026/switzerland-uefa-playoff-a.md
@@ -4,7 +4,7 @@ date: 2026-06-18T19:00Z
 endDate: 2026-06-18T20:50Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/switzerland-uefa-playoff-a/
-tags: ["Switzerland","UEFA Playoff A","Los Angeles","Group B","Group stages","FIFA World Cup 2026"]
+tags: ["Switzerland","UEFA Playoff A","Los Angeles","Group B","Group stages","World Cup 2026"]
 tv: []
 ---
 The 9th game of the FIFA World Cup 2026 group stage between Group B competitors, Switzerland and UEFA Playoff A.

--- a/src/_content/games/world-cup-2026/switzerland-uefa-playoff-a.md
+++ b/src/_content/games/world-cup-2026/switzerland-uefa-playoff-a.md
@@ -1,0 +1,10 @@
+---
+title: "Switzerland v UEFA Playoff A"
+date: 2026-06-18T19:00Z
+endDate: 2026-06-18T20:50Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/switzerland-uefa-playoff-a/
+tags: ["Switzerland","UEFA Playoff A","Los Angeles","Group B","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 9th game of the FIFA World Cup 2026 group stage between Group B competitors, Switzerland and UEFA Playoff A.

--- a/src/_content/games/world-cup-2026/tunisia-japan.md
+++ b/src/_content/games/world-cup-2026/tunisia-japan.md
@@ -4,7 +4,7 @@ date: 2026-06-21T03:00Z
 endDate: 2026-06-21T04:50Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/tunisia-japan/
-tags: ["Tunisia","Japan","Monterrey","Group F","Group stages","FIFA World Cup 2026"]
+tags: ["Tunisia","Japan","Monterrey","Group F","Group stages","World Cup 2026"]
 tv: []
 ---
 The 34th game of the FIFA World Cup 2026 group stage between Group F competitors, Tunisia and Japan.

--- a/src/_content/games/world-cup-2026/tunisia-japan.md
+++ b/src/_content/games/world-cup-2026/tunisia-japan.md
@@ -1,0 +1,10 @@
+---
+title: "Tunisia v Japan"
+date: 2026-06-21T03:00Z
+endDate: 2026-06-21T04:50Z
+locationName: "Estadio BBVA, Monterrey"
+path: /world-cup-2026/tunisia-japan/
+tags: ["Tunisia","Japan","Monterrey","Group F","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 34th game of the FIFA World Cup 2026 group stage between Group F competitors, Tunisia and Japan.

--- a/src/_content/games/world-cup-2026/tunisia-netherlands.md
+++ b/src/_content/games/world-cup-2026/tunisia-netherlands.md
@@ -1,0 +1,10 @@
+---
+title: "Tunisia v Netherlands"
+date: 2026-06-25T23:00Z
+endDate: 2026-06-26T00:50Z
+locationName: "Arrowhead Stadium, Kansas City"
+path: /world-cup-2026/tunisia-netherlands/
+tags: ["Tunisia","Netherlands","Kansas City","Group F","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 36th game of the FIFA World Cup 2026 group stage between Group F competitors, Tunisia and Netherlands.

--- a/src/_content/games/world-cup-2026/tunisia-netherlands.md
+++ b/src/_content/games/world-cup-2026/tunisia-netherlands.md
@@ -4,7 +4,7 @@ date: 2026-06-25T23:00Z
 endDate: 2026-06-26T00:50Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/tunisia-netherlands/
-tags: ["Tunisia","Netherlands","Kansas City","Group F","Group stages","FIFA World Cup 2026"]
+tags: ["Tunisia","Netherlands","Kansas City","Group F","Group stages","World Cup 2026"]
 tv: []
 ---
 The 36th game of the FIFA World Cup 2026 group stage between Group F competitors, Tunisia and Netherlands.

--- a/src/_content/games/world-cup-2026/uefa-playoff-a-qatar.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-a-qatar.md
@@ -1,0 +1,10 @@
+---
+title: "UEFA Playoff A v Qatar"
+date: 2026-06-24T19:00Z
+endDate: 2026-06-24T20:50Z
+locationName: "Lumen Field, Seattle"
+path: /world-cup-2026/uefa-playoff-a-qatar/
+tags: ["UEFA Playoff A","Qatar","Seattle","Group B","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 12th game of the FIFA World Cup 2026 group stage between Group B competitors, UEFA Playoff A and Qatar.

--- a/src/_content/games/world-cup-2026/uefa-playoff-a-qatar.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-a-qatar.md
@@ -4,7 +4,7 @@ date: 2026-06-24T19:00Z
 endDate: 2026-06-24T20:50Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/uefa-playoff-a-qatar/
-tags: ["UEFA Playoff A","Qatar","Seattle","Group B","Group stages","FIFA World Cup 2026"]
+tags: ["UEFA Playoff A","Qatar","Seattle","Group B","Group stages","World Cup 2026"]
 tv: []
 ---
 The 12th game of the FIFA World Cup 2026 group stage between Group B competitors, UEFA Playoff A and Qatar.

--- a/src/_content/games/world-cup-2026/uefa-playoff-b-tunisia.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-b-tunisia.md
@@ -4,7 +4,7 @@ date: 2026-06-15T03:00Z
 endDate: 2026-06-15T04:50Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/uefa-playoff-b-tunisia/
-tags: ["UEFA Playoff B","Tunisia","Monterrey","Group F","Group stages","FIFA World Cup 2026"]
+tags: ["UEFA Playoff B","Tunisia","Monterrey","Group F","Group stages","World Cup 2026"]
 tv: []
 ---
 The 32nd game of the FIFA World Cup 2026 group stage between Group F competitors, UEFA Playoff B and Tunisia.

--- a/src/_content/games/world-cup-2026/uefa-playoff-b-tunisia.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-b-tunisia.md
@@ -1,0 +1,10 @@
+---
+title: "UEFA Playoff B v Tunisia"
+date: 2026-06-15T03:00Z
+endDate: 2026-06-15T04:50Z
+locationName: "Estadio BBVA, Monterrey"
+path: /world-cup-2026/uefa-playoff-b-tunisia/
+tags: ["UEFA Playoff B","Tunisia","Monterrey","Group F","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 32nd game of the FIFA World Cup 2026 group stage between Group F competitors, UEFA Playoff B and Tunisia.

--- a/src/_content/games/world-cup-2026/uefa-playoff-c-paraguay.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-c-paraguay.md
@@ -4,7 +4,7 @@ date: 2026-06-20T04:00Z
 endDate: 2026-06-20T05:50Z
 locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/uefa-playoff-c-paraguay/
-tags: ["UEFA Playoff C","Paraguay","San Francisco","Group D","Group stages","FIFA World Cup 2026"]
+tags: ["UEFA Playoff C","Paraguay","San Francisco","Group D","Group stages","World Cup 2026"]
 tv: []
 ---
 The 21st game of the FIFA World Cup 2026 group stage between Group D competitors, UEFA Playoff C and Paraguay.

--- a/src/_content/games/world-cup-2026/uefa-playoff-c-paraguay.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-c-paraguay.md
@@ -1,0 +1,10 @@
+---
+title: "UEFA Playoff C v Paraguay"
+date: 2026-06-20T04:00Z
+endDate: 2026-06-20T05:50Z
+locationName: "Levi's Stadium, San Francisco"
+path: /world-cup-2026/uefa-playoff-c-paraguay/
+tags: ["UEFA Playoff C","Paraguay","San Francisco","Group D","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 21st game of the FIFA World Cup 2026 group stage between Group D competitors, UEFA Playoff C and Paraguay.

--- a/src/_content/games/world-cup-2026/uefa-playoff-c-usa.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-c-usa.md
@@ -4,7 +4,7 @@ date: 2026-06-26T02:00Z
 endDate: 2026-06-26T03:50Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/uefa-playoff-c-usa/
-tags: ["UEFA Playoff C","USA","Los Angeles","Group D","Group stages","FIFA World Cup 2026"]
+tags: ["UEFA Playoff C","USA","Los Angeles","Group D","Group stages","World Cup 2026"]
 tv: []
 ---
 The 23rd game of the FIFA World Cup 2026 group stage between Group D competitors, UEFA Playoff C and USA.

--- a/src/_content/games/world-cup-2026/uefa-playoff-c-usa.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-c-usa.md
@@ -1,0 +1,10 @@
+---
+title: "UEFA Playoff C v USA"
+date: 2026-06-26T02:00Z
+endDate: 2026-06-26T03:50Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/uefa-playoff-c-usa/
+tags: ["UEFA Playoff C","USA","Los Angeles","Group D","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 23rd game of the FIFA World Cup 2026 group stage between Group D competitors, UEFA Playoff C and USA.

--- a/src/_content/games/world-cup-2026/uefa-playoff-d-south-africa.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-d-south-africa.md
@@ -4,7 +4,7 @@ date: 2026-06-18T16:00Z
 endDate: 2026-06-18T17:50Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/uefa-playoff-d-south-africa/
-tags: ["UEFA Playoff D","South Africa","Atlanta","Group A","Group stages","FIFA World Cup 2026"]
+tags: ["UEFA Playoff D","South Africa","Atlanta","Group A","Group stages","World Cup 2026"]
 tv: []
 ---
 The 3rd game of the FIFA World Cup 2026 group stage between Group A competitors, UEFA Playoff D and South Africa.

--- a/src/_content/games/world-cup-2026/uefa-playoff-d-south-africa.md
+++ b/src/_content/games/world-cup-2026/uefa-playoff-d-south-africa.md
@@ -1,0 +1,10 @@
+---
+title: "UEFA Playoff D v South Africa"
+date: 2026-06-18T16:00Z
+endDate: 2026-06-18T17:50Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/uefa-playoff-d-south-africa/
+tags: ["UEFA Playoff D","South Africa","Atlanta","Group A","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 3rd game of the FIFA World Cup 2026 group stage between Group A competitors, UEFA Playoff D and South Africa.

--- a/src/_content/games/world-cup-2026/uruguay-cape-verde.md
+++ b/src/_content/games/world-cup-2026/uruguay-cape-verde.md
@@ -4,7 +4,7 @@ date: 2026-06-21T22:00Z
 endDate: 2026-06-21T23:50Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/uruguay-cape-verde/
-tags: ["Uruguay","Cape Verde","Miami","Group H","Group stages","FIFA World Cup 2026"]
+tags: ["Uruguay","Cape Verde","Miami","Group H","Group stages","World Cup 2026"]
 tv: []
 ---
 The 46th game of the FIFA World Cup 2026 group stage between Group H competitors, Uruguay and Cape Verde.

--- a/src/_content/games/world-cup-2026/uruguay-cape-verde.md
+++ b/src/_content/games/world-cup-2026/uruguay-cape-verde.md
@@ -1,0 +1,10 @@
+---
+title: "Uruguay v Cape Verde"
+date: 2026-06-21T22:00Z
+endDate: 2026-06-21T23:50Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/uruguay-cape-verde/
+tags: ["Uruguay","Cape Verde","Miami","Group H","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 46th game of the FIFA World Cup 2026 group stage between Group H competitors, Uruguay and Cape Verde.

--- a/src/_content/games/world-cup-2026/uruguay-spain.md
+++ b/src/_content/games/world-cup-2026/uruguay-spain.md
@@ -4,7 +4,7 @@ date: 2026-06-27T01:00Z
 endDate: 2026-06-27T02:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/uruguay-spain/
-tags: ["Uruguay","Spain","Guadalajara","Group H","Group stages","FIFA World Cup 2026"]
+tags: ["Uruguay","Spain","Guadalajara","Group H","Group stages","World Cup 2026"]
 tv: []
 ---
 The 48th game of the FIFA World Cup 2026 group stage between Group H competitors, Uruguay and Spain.

--- a/src/_content/games/world-cup-2026/uruguay-spain.md
+++ b/src/_content/games/world-cup-2026/uruguay-spain.md
@@ -1,0 +1,10 @@
+---
+title: "Uruguay v Spain"
+date: 2026-06-27T01:00Z
+endDate: 2026-06-27T02:50Z
+locationName: "Estadio Akron, Guadalajara"
+path: /world-cup-2026/uruguay-spain/
+tags: ["Uruguay","Spain","Guadalajara","Group H","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 48th game of the FIFA World Cup 2026 group stage between Group H competitors, Uruguay and Spain.

--- a/src/_content/games/world-cup-2026/usa-australia.md
+++ b/src/_content/games/world-cup-2026/usa-australia.md
@@ -4,7 +4,7 @@ date: 2026-06-19T22:00Z
 endDate: 2026-06-19T23:50Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/usa-australia/
-tags: ["USA","Australia","Seattle","Group D","Group stages","FIFA World Cup 2026"]
+tags: ["USA","Australia","Seattle","Group D","Group stages","World Cup 2026"]
 tv: []
 ---
 The 22nd game of the FIFA World Cup 2026 group stage between Group D competitors, USA and Australia.

--- a/src/_content/games/world-cup-2026/usa-australia.md
+++ b/src/_content/games/world-cup-2026/usa-australia.md
@@ -1,0 +1,10 @@
+---
+title: "USA v Australia"
+date: 2026-06-19T22:00Z
+endDate: 2026-06-19T23:50Z
+locationName: "Lumen Field, Seattle"
+path: /world-cup-2026/usa-australia/
+tags: ["USA","Australia","Seattle","Group D","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 22nd game of the FIFA World Cup 2026 group stage between Group D competitors, USA and Australia.

--- a/src/_content/games/world-cup-2026/usa-paraguay.md
+++ b/src/_content/games/world-cup-2026/usa-paraguay.md
@@ -1,0 +1,10 @@
+---
+title: "USA v Paraguay"
+date: 2026-06-13T01:00Z
+endDate: 2026-06-13T02:50Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/usa-paraguay/
+tags: ["USA","Paraguay","Los Angeles","Group D","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 19th game of the FIFA World Cup 2026 group stage between Group D competitors, USA and Paraguay.

--- a/src/_content/games/world-cup-2026/usa-paraguay.md
+++ b/src/_content/games/world-cup-2026/usa-paraguay.md
@@ -4,7 +4,7 @@ date: 2026-06-13T01:00Z
 endDate: 2026-06-13T02:50Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/usa-paraguay/
-tags: ["USA","Paraguay","Los Angeles","Group D","Group stages","FIFA World Cup 2026"]
+tags: ["USA","Paraguay","Los Angeles","Group D","Group stages","World Cup 2026"]
 tv: []
 ---
 The 19th game of the FIFA World Cup 2026 group stage between Group D competitors, USA and Paraguay.

--- a/src/_content/games/world-cup-2026/uzbekistan-colombia.md
+++ b/src/_content/games/world-cup-2026/uzbekistan-colombia.md
@@ -4,7 +4,7 @@ date: 2026-06-18T03:00Z
 endDate: 2026-06-18T04:50Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/uzbekistan-colombia/
-tags: ["Uzbekistan","Colombia","Mexico City","Group K","Group stages","FIFA World Cup 2026"]
+tags: ["Uzbekistan","Colombia","Mexico City","Group K","Group stages","World Cup 2026"]
 tv: []
 ---
 The 62nd game of the FIFA World Cup 2026 group stage between Group K competitors, Uzbekistan and Colombia.

--- a/src/_content/games/world-cup-2026/uzbekistan-colombia.md
+++ b/src/_content/games/world-cup-2026/uzbekistan-colombia.md
@@ -1,0 +1,10 @@
+---
+title: "Uzbekistan v Colombia"
+date: 2026-06-18T03:00Z
+endDate: 2026-06-18T04:50Z
+locationName: "Estadio Azteca, Mexico City"
+path: /world-cup-2026/uzbekistan-colombia/
+tags: ["Uzbekistan","Colombia","Mexico City","Group K","Group stages","FIFA World Cup 2026"]
+tv: []
+---
+The 62nd game of the FIFA World Cup 2026 group stage between Group K competitors, Uzbekistan and Colombia.

--- a/src/_data/competitions.json
+++ b/src/_data/competitions.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "FIFA World Cup 2026",
+    "path": "/world-cup-2026/",
+    "start": "2026-06-11",
+    "end": "2026-07-19"
+  },
+  {
     "title": "EURO 2025",
     "path": "/euro-2025/",
     "start": "2025-07-02",


### PR DESCRIPTION
72 group stage match files across 12 groups (A–L), covering all
matches from June 11–27, 2026 across 16 venues in USA, Canada, and
Mexico. Times stored in UTC, converted from local venue timezones
(EDT/CDT/CST/PDT). Six team slots marked as TBD pending playoff
results (UEFA Playoff A/B/C/D, IC Playoff 1/2).

Also adds World Cup 2026 to competitions.json.

https://claude.ai/code/session_013Xw2u8wmgsqGxjgjy7HEFj