### PR TITLE
Add location-based colour themes for each competition

### DIFF
--- a/src/_assets/css/_layout.css
+++ b/src/_assets/css/_layout.css
@@ -240,9 +240,11 @@ html {
 }
 
 body {
+  --color-a: #D55A5A;
+  --color-b: #135A94;
   text-align: left;
-  background-color: #D55A5A;
-  background-image: linear-gradient(120deg, #D55A5A 50%, #135A94 50%);
+  background-color: var(--color-a);
+  background-image: linear-gradient(120deg, var(--color-a) 50%, var(--color-b) 50%);
   color: rgb(30 30 30 / 80%);
   font-family: Helvetica, sans-serif;
   font-weight: normal;
@@ -250,6 +252,11 @@ body {
   font-kerning: normal;
   font-feature-settings: "kern", "liga", "clig", "calt";
 }
+
+body[data-theme="world-cup-2026"] { --color-a: #BF0A30; --color-b: #006847; }
+body[data-theme="euro-2025"]      { --color-a: #DA291C; --color-b: #1565C0; }
+body[data-theme="euro-2024"]      { --color-a: #1C1C1C; --color-b: #FFCC00; }
+body[data-theme="euro-2020"]      { --color-a: #003FA0; --color-b: #E87722; }
 
 img {
   max-width: 100%;

--- a/src/_data/competitions.json
+++ b/src/_data/competitions.json
@@ -1,24 +1,28 @@
 [
   {
     "title": "FIFA World Cup 2026",
+    "theme": "world-cup-2026",
     "path": "/world-cup-2026/",
     "start": "2026-06-11",
     "end": "2026-07-19"
   },
   {
     "title": "EURO 2025",
+    "theme": "euro-2025",
     "path": "/euro-2025/",
     "start": "2025-07-02",
     "end": "2025-07-27"
   },
   {
     "title": "EURO 2024",
+    "theme": "euro-2024",
     "path": "/euro-2024/",
     "start": "2024-06-14",
     "end": "2024-07-14"
   },
   {
     "title": "EURO 2020",
+    "theme": "euro-2020",
     "path": "/euro-2020/",
     "start": "2021-06-11",
     "end": "2021-07-11"

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -20,7 +20,7 @@
             posthog.init('{{ config.POSTHOG_KEY }}', {api_host: '{{ config.POSTHOG_HOST }}'})
         </script>
     </head>
-    <body class="{{ bodyClass }}">
+    <body class="{{ bodyClass }}"{% if competitionTheme %} data-theme="{{ competitionTheme }}"{% endif %}>
         <header>
             <div>
                 <h1>

--- a/src/_layouts/games.njk
+++ b/src/_layouts/games.njk
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
 ---
-
+{% for comp in competitions %}{% if comp.title == tag %}{% set competitionTheme = comp.theme %}{% endif %}{% endfor %}
 <h1>{{ tag }} Games</h1>
 <p class="subscribe">
     <a href="{{ ('/' + (tag | slugify) + '/') | url | absoluteUrl(config.baseUrl) | webcal }}">


### PR DESCRIPTION
Each competition page now gets a diagonal background derived from its
host country's colours: World Cup 2026 (USA red + Mexico green), EURO
2025 (Swiss red + alpine blue), EURO 2024 (German black + gold), EURO
2020 (UEFA blue + amber). The homepage retains the original palette.

Implemented via CSS custom properties (--color-a/--color-b) on body,
with data-theme attributes set from competitions.json theme slugs.

https://claude.ai/code/session_011KpkXMpVroQSfJabbfjHEm