### PR TITLE
Fix opmlparser@^2.0.0 unresolvable transitive dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "lint:css:fix": "npm run lint:css -- --fix",
     "test": "echo \"Warning: No tests\" && exit 0"
   },
+  "overrides": {
+    "opmlparser": "0.8.0"
+  },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
     "autoprefixer": "^10.4.19",


### PR DESCRIPTION
opmlparser has never published a v2 release (latest is 0.8.0), so any
transitive dep requiring ^2.0.0 causes npm to fail with ETARGET during
the Docker production build (npm install --omit=dev --ignore-scripts).

Add an npm overrides entry to force any resolution of opmlparser to
use 0.8.0, the highest available version, regardless of the semver
range requested by a transitive dependency.

https://claude.ai/code/session_016dFeZ6LbQzJrzPWkvxwqPq