### PR TITLE
Fix homepage hero heading wrapping on mobile

### DIFF
--- a/src/_assets/css/_layout.css
+++ b/src/_assets/css/_layout.css
@@ -659,7 +659,7 @@ ul.competitions li {
 }
 
 #content h1 {
-  font-size: 60px;
+  font-size: clamp(2rem, 13vw, 60px);
   border-top: 8px solid #FFF;
   padding-top: 20px;
   text-align: center;


### PR DESCRIPTION
Replace fixed 60px font size with clamp(2rem, 13vw, 60px) so the
heading scales with viewport width on mobile, preventing long words
like "CALENDAR" from breaking mid-word on small screens.

https://claude.ai/code/session_01Hio7BPSzBN8Zt6KJPaunjb