### PR TITLE
Fix match page heading wrapping for long team names on mobile

### DIFF
--- a/src/_assets/css/_layout.css
+++ b/src/_assets/css/_layout.css
@@ -665,6 +665,10 @@ ul.competitions li {
   text-align: center;
 }
 
+#content .event-post > h1 {
+  font-size: clamp(2rem, 11vw, 60px);
+}
+
 .lede {
   margin-bottom: 5rem;
   text-align: center;


### PR DESCRIPTION
## Summary

- Adds a more specific CSS rule `#content .event-post > h1` targeting match page headings only
- Uses `clamp(2rem, 11vw, 60px)` instead of the homepage's `13vw`, to accommodate longer team names like "SWITZERLAND" (11 chars) without mid-word wrapping on mobile
- Desktop size (60px max) is unchanged

## Why a separate rule?

The homepage fix uses `13vw` which is tuned for 8-character words like "CALENDAR". Match page team names can be up to 11+ characters, requiring a smaller viewport-relative size. Using `#content .event-post > h1` (higher specificity than `#content h1`) keeps the two concerns independent.

## Test plan

- [ ] Check `/world-cup-2026/qatar-switzerland/` on a ~390px mobile viewport — "SWITZERLAND" should fit on one line
- [ ] Check other match pages with long team names (e.g. Netherlands, New Zealand)
- [ ] Confirm homepage heading is unaffected
- [ ] Confirm desktop layout (768px+) still renders at 60px for both pages

https://claude.ai/code/session_01Hio7BPSzBN8Zt6KJPaunjb