### PR TITLE
Add Buy Me a Coffee widget to base layout

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -53,6 +53,7 @@
                     
                 </p>
             </footer>
+            <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="si" data-description="Buy us a coffee to say thank you" data-message="" data-color="#5F7FFF" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
         </div>
         <div id="cookie-banner" style="display:none;">
           <span>


### PR DESCRIPTION
## Summary
Added a Buy Me a Coffee widget to the base layout template to enable visitors to support the project through donations.

## Changes
- Integrated Buy Me a Coffee widget script into the base layout footer
- Widget configured with:
  - Custom branding color (#5F7FFF)
  - Right-side positioning with 18px margins
  - Custom message prompting visitors to "Buy us a coffee to say thank you"
  - Account ID set to "si"

## Implementation Details
The widget script is placed after the footer closing tag and includes the necessary data attributes for configuration. The `data-cfasync="false"` attribute ensures proper async script handling.

https://claude.ai/code/session_011PGgbLMAVhpttUFGoo6Dde