### PR TITLE
Fade past events and highlight next event using local timezone

### DIFF
--- a/src/_assets/css/_event.css
+++ b/src/_assets/css/_event.css
@@ -38,7 +38,12 @@ tr:last-child td {
 }
 
 tr.past {
-    opacity: 0.4;
+    opacity: 0.5;
+}
+
+tr.next {
+    transform: scale(1.05);
+    transform-origin: center center;
 }
 
 td.summary {

--- a/src/_layouts/games.njk
+++ b/src/_layouts/games.njk
@@ -49,6 +49,34 @@ layout: base.njk
         {% endfor %}
     </tbody>
 </table>
+<script>
+(function () {
+  var now = new Date()
+  var rows = document.querySelectorAll('tr.vevent')
+  var nextFound = false
+
+  rows.forEach(function (row) {
+    var dtEnd = row.querySelector('time.dt-end')
+    var dtStart = row.querySelector('time.dt-start')
+    var endText = dtEnd && dtEnd.textContent.trim()
+    var endTime = endText ? new Date(endText) : null
+
+    if (!endTime || isNaN(endTime.getTime())) {
+      var startText = dtStart && dtStart.textContent.trim()
+      endTime = startText ? new Date(startText) : null
+    }
+
+    if (!endTime || isNaN(endTime.getTime())) return
+
+    if (endTime < now) {
+      row.classList.add('past')
+    } else if (!nextFound) {
+      row.classList.add('next')
+      nextFound = true
+    }
+  })
+})()
+</script>
 <h2>Want more?</h2>
 <p>
     <a href="{{ '/' | url | absoluteUrl(config.baseUrl) }}">All games</a>


### PR DESCRIPTION
On tag listing pages, client-side JS reads the dt-end time elements
and compares them to the user's local time to classify rows as past
or next. Past events are faded to 50% opacity; the next upcoming
event is scaled up slightly to stand out.

https://claude.ai/code/session_014mt7UTgdmpwu8ZRNrkHS9F