### PR TITLE
fix: correct kickoff times for 12 World Cup 2026 fixtures

### DIFF
--- a/src/_content/games/world-cup-2026/argentina-austria.md
+++ b/src/_content/games/world-cup-2026/argentina-austria.md
@@ -1,7 +1,7 @@
 ---
 title: "Argentina v Austria"
-date: 2026-06-22T18:00Z
-endDate: 2026-06-22T19:50Z
+date: 2026-06-22T17:00Z
+endDate: 2026-06-22T18:50Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/argentina-austria/
 tags: ["Argentina","Austria","Dallas","Group J","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/colombia-dr-congo.md
+++ b/src/_content/games/world-cup-2026/colombia-dr-congo.md
@@ -1,7 +1,7 @@
 ---
 title: "Colombia v DR Congo"
-date: 2026-06-24T03:00Z
-endDate: 2026-06-24T04:50Z
+date: 2026-06-24T02:00Z
+endDate: 2026-06-24T03:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/colombia-dr-congo/
 redirectFrom: /world-cup-2026/colombia-ic-playoff-1/

--- a/src/_content/games/world-cup-2026/mexico-czechia.md
+++ b/src/_content/games/world-cup-2026/mexico-czechia.md
@@ -1,7 +1,7 @@
 ---
 title: "Mexico v Czechia"
-date: 2026-06-25T02:00Z
-endDate: 2026-06-25T03:50Z
+date: 2026-06-25T01:00Z
+endDate: 2026-06-25T02:50Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/mexico-czechia/
 redirectFrom: /world-cup-2026/mexico-uefa-playoff-d/

--- a/src/_content/games/world-cup-2026/mexico-south-africa.md
+++ b/src/_content/games/world-cup-2026/mexico-south-africa.md
@@ -1,7 +1,7 @@
 ---
 title: "Mexico v South Africa"
-date: 2026-06-11T20:00Z
-endDate: 2026-06-11T21:50Z
+date: 2026-06-11T19:00Z
+endDate: 2026-06-11T20:50Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/mexico-south-africa/
 tags: ["Mexico","South Africa","Mexico City","Group A","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/mexico-south-korea.md
+++ b/src/_content/games/world-cup-2026/mexico-south-korea.md
@@ -1,7 +1,7 @@
 ---
 title: "Mexico v South Korea"
-date: 2026-06-19T02:00Z
-endDate: 2026-06-19T03:50Z
+date: 2026-06-19T01:00Z
+endDate: 2026-06-19T02:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/mexico-south-korea/
 tags: ["Mexico","South Korea","Guadalajara","Group A","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/south-africa-south-korea.md
+++ b/src/_content/games/world-cup-2026/south-africa-south-korea.md
@@ -1,7 +1,7 @@
 ---
 title: "South Africa v South Korea"
-date: 2026-06-25T02:00Z
-endDate: 2026-06-25T03:50Z
+date: 2026-06-25T01:00Z
+endDate: 2026-06-25T02:50Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/south-africa-south-korea/
 tags: ["South Africa","South Korea","Monterrey","Group A","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/south-korea-czechia.md
+++ b/src/_content/games/world-cup-2026/south-korea-czechia.md
@@ -1,7 +1,7 @@
 ---
 title: "South Korea v Czechia"
-date: 2026-06-12T03:00Z
-endDate: 2026-06-12T04:50Z
+date: 2026-06-12T02:00Z
+endDate: 2026-06-12T03:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/south-korea-czechia/
 redirectFrom: /world-cup-2026/south-korea-uefa-playoff-d/

--- a/src/_content/games/world-cup-2026/sweden-tunisia.md
+++ b/src/_content/games/world-cup-2026/sweden-tunisia.md
@@ -1,7 +1,7 @@
 ---
 title: "Sweden v Tunisia"
-date: 2026-06-15T03:00Z
-endDate: 2026-06-15T04:50Z
+date: 2026-06-15T02:00Z
+endDate: 2026-06-15T03:50Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/sweden-tunisia/
 redirectFrom: /world-cup-2026/uefa-playoff-b-tunisia/

--- a/src/_content/games/world-cup-2026/tunisia-japan.md
+++ b/src/_content/games/world-cup-2026/tunisia-japan.md
@@ -1,7 +1,7 @@
 ---
 title: "Tunisia v Japan"
-date: 2026-06-21T03:00Z
-endDate: 2026-06-21T04:50Z
+date: 2026-06-21T04:00Z
+endDate: 2026-06-21T05:50Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/tunisia-japan/
 tags: ["Tunisia","Japan","Monterrey","Group F","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/uruguay-spain.md
+++ b/src/_content/games/world-cup-2026/uruguay-spain.md
@@ -1,7 +1,7 @@
 ---
 title: "Uruguay v Spain"
-date: 2026-06-27T01:00Z
-endDate: 2026-06-27T02:50Z
+date: 2026-06-27T00:00Z
+endDate: 2026-06-27T01:50Z
 locationName: "Estadio Akron, Guadalajara"
 path: /world-cup-2026/uruguay-spain/
 tags: ["Uruguay","Spain","Guadalajara","Group H","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/usa-australia.md
+++ b/src/_content/games/world-cup-2026/usa-australia.md
@@ -1,7 +1,7 @@
 ---
 title: "USA v Australia"
-date: 2026-06-19T22:00Z
-endDate: 2026-06-19T23:50Z
+date: 2026-06-19T19:00Z
+endDate: 2026-06-19T20:50Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/usa-australia/
 tags: ["USA","Australia","Seattle","Group D","Group stages","World Cup 2026"]

--- a/src/_content/games/world-cup-2026/uzbekistan-colombia.md
+++ b/src/_content/games/world-cup-2026/uzbekistan-colombia.md
@@ -1,7 +1,7 @@
 ---
 title: "Uzbekistan v Colombia"
-date: 2026-06-18T03:00Z
-endDate: 2026-06-18T04:50Z
+date: 2026-06-18T02:00Z
+endDate: 2026-06-18T03:50Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/uzbekistan-colombia/
 tags: ["Uzbekistan","Colombia","Mexico City","Group K","Group stages","World Cup 2026"]


### PR DESCRIPTION
Cross-checked against official sources (FIFA, FOX Sports, venue sites,
Sky Sports BST times). Most errors were 1 hour late, likely due to
Mexico no longer observing DST (now permanently UTC-6) or confusing
CDT with EDT when converting match times to UTC.

Fixes:
- Mexico v South Africa: 20:00Z → 19:00Z (opening game, 3PM ET / 1PM local)
- South Korea v Czechia: 03:00Z → 02:00Z (10PM ET / 8PM local Guadalajara)
- Sweden v Tunisia: 03:00Z → 02:00Z (10PM ET / 8PM local Monterrey)
- USA v Australia: 22:00Z → 19:00Z (3PM ET / 12PM local Seattle)
- Uzbekistan v Colombia: 03:00Z → 02:00Z (10PM ET / 8PM local Mexico City)
- Mexico v South Korea: 02:00Z → 01:00Z (9PM ET / 7PM local Guadalajara)
- Argentina v Austria: 18:00Z → 17:00Z (1PM ET / noon local Dallas)
- Colombia v DR Congo: 03:00Z → 02:00Z (10PM ET / 8PM local Guadalajara)
- Mexico v Czechia: 02:00Z → 01:00Z (9PM ET / 7PM local Mexico City)
- South Africa v South Korea: 02:00Z → 01:00Z (9PM ET / 7PM local Monterrey)
- Tunisia v Japan: 03:00Z → 04:00Z (midnight ET / 10PM local Monterrey)
- Uruguay v Spain: 01:00Z → 00:00Z (8PM ET / 6PM local Guadalajara)

https://claude.ai/code/session_01SvFEWcSSGGXv5s8brpbyJH