### PR TITLE
Implement client-side timezone localization for game times and dates

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -40,7 +40,8 @@ module.exports = config => {
   config.addFilter('commaNumber', n => Number(n).toLocaleString('en-GB'))
 
   config.addPassthroughCopy({
-    'src/_assets/img': 'img'
+    'src/_assets/img': 'img',
+    'src/_assets/js': 'js'
   })
 
   return {

--- a/src/_assets/css/site.css
+++ b/src/_assets/css/site.css
@@ -51,6 +51,7 @@ h1, h2, h3, h4, h5, h6 {
 .datetime {
   font-family: 'Roboto Slab', Arial, Helvetica, sans-serif;
   font-weight: 900;
+  flex-wrap: wrap;
 }
 
 .ad-container {
@@ -156,4 +157,13 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   gap: 1.5em;
   flex-wrap: wrap;
+}
+
+.timezone-info {
+  flex-basis: 100%;
+  text-align: center;
+  font-variant: all-small-caps;
+  font-size: 0.9em;
+  margin-top: 1rem;
+  opacity: 0.7;
 }

--- a/src/_assets/css/site.css
+++ b/src/_assets/css/site.css
@@ -48,10 +48,13 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 900;
 }
 
+.event-post .datetime {
+  flex-wrap: wrap;
+}
+
 .datetime {
   font-family: 'Roboto Slab', Arial, Helvetica, sans-serif;
   font-weight: 900;
-  flex-wrap: wrap;
 }
 
 .ad-container {
@@ -161,9 +164,12 @@ h1, h2, h3, h4, h5, h6 {
 
 .timezone-info {
   flex-basis: 100%;
+  width: 100%;
   text-align: center;
+  font-family: 'Roboto Slab', Arial, Helvetica, sans-serif;
+  font-size: 1.1rem;
+  letter-spacing: 0.4em;
   font-variant: all-small-caps;
-  font-size: 0.9em;
   margin-top: 1rem;
   opacity: 0.7;
 }

--- a/src/_assets/js/timezone-localizer.js
+++ b/src/_assets/js/timezone-localizer.js
@@ -1,0 +1,99 @@
+(function() {
+  function getOrdinal(n) {
+    const s = ['th', 'st', 'nd', 'rd'];
+    const v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+  }
+
+  function formatLocalDate(date) {
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    return `${days[date.getDay()]} ${getOrdinal(date.getDate())} ${months[date.getMonth()]}`;
+  }
+
+  function localize() {
+    const now = new Date();
+    const offsetMinutes = -now.getTimezoneOffset();
+    const absOffset = Math.abs(offsetMinutes);
+    const hours = Math.floor(absOffset / 60);
+    const minutes = absOffset % 60;
+    const offsetStr = (offsetMinutes >= 0 ? '+' : '-') +
+      String(hours).padStart(2, '0') + ':' +
+      String(minutes).padStart(2, '0');
+
+    const infoElements = document.querySelectorAll('.timezone-info');
+    infoElements.forEach(el => {
+      el.textContent = `Based on your local timezone ${offsetStr}`;
+      el.style.display = 'block';
+    });
+
+    let lastDate = null;
+    const games = document.querySelectorAll('.h-event');
+    games.forEach(game => {
+      const startEl = game.querySelector('.dt-start');
+      const endEl = game.querySelector('.dt-end');
+      const daySpan = game.querySelector('.day') || game.querySelector('.date');
+      const timeSpan = game.querySelector('.starttime');
+      const endTimeSpan = game.querySelector('.endtime');
+
+      const startAttr = startEl ? startEl.getAttribute('datetime') : null;
+      if (!startAttr) return;
+
+      const startDate = new Date(startAttr);
+      if (isNaN(startDate.getTime())) return;
+
+      // Update day
+      if (daySpan) {
+        const dateKey = startDate.toDateString();
+        const isTimeline = game.tagName === 'TR';
+        if (isTimeline && dateKey === lastDate) {
+          daySpan.textContent = '';
+        } else {
+          daySpan.textContent = formatLocalDate(startDate);
+          lastDate = dateKey;
+        }
+      }
+
+      // Update time
+      if (timeSpan) {
+        const isTimeline = game.tagName === 'TR';
+        if (isTimeline) {
+          // 24h format for timeline: H:mm
+          const hours = startDate.getHours();
+          const mins = String(startDate.getMinutes()).padStart(2, '0');
+          timeSpan.textContent = `${hours}:${mins}`;
+        } else {
+          // 12h format for detail: h:mma
+          let hours = startDate.getHours();
+          const ampm = hours >= 12 ? 'pm' : 'am';
+          hours = hours % 12;
+          hours = hours || 12;
+          const mins = String(startDate.getMinutes()).padStart(2, '0');
+          timeSpan.textContent = `${hours}:${mins}${ampm}`;
+        }
+      }
+
+      // Update end time
+      if (endTimeSpan && endEl) {
+        const endAttr = endEl.getAttribute('datetime');
+        if (endAttr) {
+          const endDate = new Date(endAttr);
+          if (!isNaN(endDate.getTime())) {
+            let hours = endDate.getHours();
+            const ampm = hours >= 12 ? 'pm' : 'am';
+            hours = hours % 12;
+            hours = hours || 12;
+            const mins = String(endDate.getMinutes()).padStart(2, '0');
+            endTimeSpan.textContent = `–${hours}:${mins}${ampm}`;
+          }
+        }
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', localize);
+  } else {
+    localize();
+  }
+})();

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -18,6 +18,7 @@
             document.getElementsByTagName('html')[0].className += ' js';
         </script>
         <link rel="stylesheet" href="{{ "/css/site.css" | url | absoluteUrl(config.baseUrl) }}"/>
+        <script src="{{ "/js/timezone-localizer.js" | url | absoluteUrl(config.baseUrl) }}" defer></script>
         {% if config.GOOGLE_ADSENSE_PUBLISHER_ID %}
         <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ config.GOOGLE_ADSENSE_PUBLISHER_ID }}" crossorigin="anonymous"></script>
         {% endif %}

--- a/src/_layouts/game.njk
+++ b/src/_layouts/game.njk
@@ -14,8 +14,9 @@ layout: base.njk
             <span class="starttime">{{ date | date('h:mma') }}</span>
             <span class="endtime">–{{ endDate | date('h:mma') }}</span>
         </p>
-        <time class="dt-start">{{ date | date("yyyy-LL-dd'T'HH:mm:ssZZZ") }}</time>
-        <time class="dt-end">{{ endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}</time>
+        <time class="dt-start" datetime="{{ date | date("yyyy-LL-dd'T'HH:mm:ssZZZ") }}">{{ date | date("yyyy-LL-dd'T'HH:mm:ssZZZ") }}</time>
+        <time class="dt-end" datetime="{{ endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}">{{ endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}</time>
+        <p class="timezone-info" style="display:none;"></p>
     </div>
 
     <p class="subscribe">

--- a/src/_layouts/games.njk
+++ b/src/_layouts/games.njk
@@ -37,17 +37,21 @@ layout: base.njk
         </tr>
     </thead>
     <tbody>
+        {% set lastDate = '' %}
         {% for game in collections[tag] %}
+            {% set showDate = false %}
+            {% if game.data.date | date('ccc dS LLLL') != lastDate %}
+                {% set lastDate = game.data.date | date('ccc dS LLLL') %}
+                {% set showDate = true %}
+            {% endif %}
             <tr class="vevent h-event">
                 <td class="datetime">
-                    {% if showDate(game.data.date, loop.index0, collections[tag]) %}
-                        <span class="day">{{ game.data.date | date('ccc dS LLLL') }}</span>
-                    {% endif %}
+                    <span class="day">{% if showDate %}{{ game.data.date | date('ccc dS LLLL') }}{% endif %}</span>
                 </td>
                 <td class="time">
-                    <span>{{ game.data.date | date('H:mm') }}</span>
-                    <time class="dt-start">{{ game.data.date | date("yyyy-LL-dd'T'HH:mm:ssZZZ") }}</time>
-                    <time class="dt-end">{{ game.data.endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}</time>
+                    <span class="starttime">{{ game.data.date | date('H:mm') }}</span>
+                    <time class="dt-start" datetime="{{ game.data.date | date("yyyy-LL-dd'T'HH:mm:ssZZZ") }}">{{ game.data.date | date("yyyy-LL-dd'T'HH:mm:ssZZZ") }}</time>
+                    <time class="dt-end" datetime="{{ game.data.endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}">{{ game.data.endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}</time>
                 </td>
                 <td class="summary">
                     <a class="p-name u-url" href="{{ game.page.url | url | absoluteUrl(config.baseUrl) }}">{{ game.data.title }}</a>
@@ -56,6 +60,7 @@ layout: base.njk
         {% endfor %}
     </tbody>
 </table>
+<p class="timezone-info" style="display:none;"></p>
 <script>
 (function () {
   var now = new Date()


### PR DESCRIPTION
Implemented client-side timezone localization for both match timeline and detail views.

Key changes:
1.  **Client-Side Localization**: Created `src/_assets/js/timezone-localizer.js` which reads UTC timestamps from `datetime` attributes on `<time>` tags and converts them to the visitor's local browser timezone.
2.  **UI Updates**: 
    - Added a centered message "Based on your local timezone +XX:XX" in small caps underneath the time/date sections on both views.
    - Timeline view (games) uses 24h format.
    - Detail view (game) uses 12h format with am/pm (e.g., 8:00pm).
3.  **Robustness**: 
    - Handled day-heading deduplication in the timeline view, ensuring that if matches shift to a new day in the local timezone, the date header is correctly displayed or hidden.
    - Maintained server-side rendering (SSR) as a fallback; the script enhances the page once loaded.
4.  **Configuration**: Updated `eleventy.config.js` to serve the new JS asset.
5.  **Verification**: Tested and verified across multiple timezones (London, New York, Tokyo) to ensure correct date rollovers and formatting.

---
*PR created automatically by Jules for task [3156121193495739968](https://jules.google.com/task/3156121193495739968) started by @si*