### PR TITLE
Add World Cup 2026 knockout stage match fixtures

### DIFF
--- a/src/_content/games/world-cup-2026/final.md
+++ b/src/_content/games/world-cup-2026/final.md
@@ -1,0 +1,10 @@
+---
+title: "Semi-final 1 winner v Semi-final 2 winner"
+date: 2026-07-19T19:00Z
+endDate: 2026-07-19T21:00Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/final/
+tags: ["Final", "New York New Jersey", "World Cup 2026"]
+tv: []
+---
+The FIFA World Cup 2026 Final at MetLife Stadium, New York/New Jersey.

--- a/src/_content/games/world-cup-2026/final.md
+++ b/src/_content/games/world-cup-2026/final.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/final/
 tags: ["Final", "New York New Jersey", "World Cup 2026"]
 tv: []
 ---
-The FIFA World Cup 2026 Final at MetLife Stadium, New York/New Jersey.
+The 104th and final game of the FIFA World Cup 2026 – the Final at MetLife Stadium, New York/New Jersey.

--- a/src/_content/games/world-cup-2026/quarter-final-1.md
+++ b/src/_content/games/world-cup-2026/quarter-final-1.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/quarter-final-1/
 tags: ["Quarter-final", "Boston", "World Cup 2026"]
 tv: []
 ---
-Quarter-final in the FIFA World Cup 2026 at Boston. Features the winners of Round of 16 matches 1 (Philadelphia) and 2 (Houston).
+The 97th game of the FIFA World Cup 2026 – a quarter-final at Gillette Stadium, Boston. Features the winners of Round of 16 matches 1 (Philadelphia) and 2 (Houston).

--- a/src/_content/games/world-cup-2026/quarter-final-1.md
+++ b/src/_content/games/world-cup-2026/quarter-final-1.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 16 match 1 winner v Round of 16 match 2 winner"
+date: 2026-07-09T20:00Z
+endDate: 2026-07-09T22:00Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/quarter-final-1/
+tags: ["Quarter-final", "Boston", "World Cup 2026"]
+tv: []
+---
+Quarter-final in the FIFA World Cup 2026 at Boston. Features the winners of Round of 16 matches 1 (Philadelphia) and 2 (Houston).

--- a/src/_content/games/world-cup-2026/quarter-final-2.md
+++ b/src/_content/games/world-cup-2026/quarter-final-2.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 16 match 5 winner v Round of 16 match 6 winner"
+date: 2026-07-10T19:00Z
+endDate: 2026-07-10T21:00Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/quarter-final-2/
+tags: ["Quarter-final", "Los Angeles", "World Cup 2026"]
+tv: []
+---
+Quarter-final in the FIFA World Cup 2026 at Los Angeles. Features the winners of Round of 16 matches 5 (Dallas) and 6 (Seattle).

--- a/src/_content/games/world-cup-2026/quarter-final-2.md
+++ b/src/_content/games/world-cup-2026/quarter-final-2.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/quarter-final-2/
 tags: ["Quarter-final", "Los Angeles", "World Cup 2026"]
 tv: []
 ---
-Quarter-final in the FIFA World Cup 2026 at Los Angeles. Features the winners of Round of 16 matches 5 (Dallas) and 6 (Seattle).
+The 98th game of the FIFA World Cup 2026 – a quarter-final at SoFi Stadium, Los Angeles. Features the winners of Round of 16 matches 5 (Dallas) and 6 (Seattle).

--- a/src/_content/games/world-cup-2026/quarter-final-3.md
+++ b/src/_content/games/world-cup-2026/quarter-final-3.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/quarter-final-3/
 tags: ["Quarter-final", "Miami", "World Cup 2026"]
 tv: []
 ---
-Quarter-final in the FIFA World Cup 2026 at Miami. Features the winners of Round of 16 matches 3 (New York/New Jersey) and 4 (Mexico City).
+The 99th game of the FIFA World Cup 2026 – a quarter-final at Hard Rock Stadium, Miami. Features the winners of Round of 16 matches 3 (New York/New Jersey) and 4 (Mexico City).

--- a/src/_content/games/world-cup-2026/quarter-final-3.md
+++ b/src/_content/games/world-cup-2026/quarter-final-3.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 16 match 3 winner v Round of 16 match 4 winner"
+date: 2026-07-11T21:00Z
+endDate: 2026-07-11T23:00Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/quarter-final-3/
+tags: ["Quarter-final", "Miami", "World Cup 2026"]
+tv: []
+---
+Quarter-final in the FIFA World Cup 2026 at Miami. Features the winners of Round of 16 matches 3 (New York/New Jersey) and 4 (Mexico City).

--- a/src/_content/games/world-cup-2026/quarter-final-4.md
+++ b/src/_content/games/world-cup-2026/quarter-final-4.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/quarter-final-4/
 tags: ["Quarter-final", "Kansas City", "World Cup 2026"]
 tv: []
 ---
-Quarter-final in the FIFA World Cup 2026 at Kansas City. Features the winners of Round of 16 matches 7 (Atlanta) and 8 (Vancouver).
+The 100th game of the FIFA World Cup 2026 – a quarter-final at Arrowhead Stadium, Kansas City. Features the winners of Round of 16 matches 7 (Atlanta) and 8 (Vancouver).

--- a/src/_content/games/world-cup-2026/quarter-final-4.md
+++ b/src/_content/games/world-cup-2026/quarter-final-4.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 16 match 7 winner v Round of 16 match 8 winner"
+date: 2026-07-12T01:00Z
+endDate: 2026-07-12T03:00Z
+locationName: "Arrowhead Stadium, Kansas City"
+path: /world-cup-2026/quarter-final-4/
+tags: ["Quarter-final", "Kansas City", "World Cup 2026"]
+tv: []
+---
+Quarter-final in the FIFA World Cup 2026 at Kansas City. Features the winners of Round of 16 matches 7 (Atlanta) and 8 (Vancouver).

--- a/src/_content/games/world-cup-2026/round-of-16-1.md
+++ b/src/_content/games/world-cup-2026/round-of-16-1.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 2 winner v Round of 32 match 5 winner"
+date: 2026-07-04T21:00Z
+endDate: 2026-07-04T23:00Z
+locationName: "Lincoln Financial Field, Philadelphia"
+path: /world-cup-2026/round-of-16-1/
+tags: ["Round of 16", "Philadelphia", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Philadelphia. Features the winners of Round of 32 matches 2 (Group E winner or best third-placed team) and 5 (Group I winner or best third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-1.md
+++ b/src/_content/games/world-cup-2026/round-of-16-1.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-1/
 tags: ["Round of 16", "Philadelphia", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Philadelphia. Features the winners of Round of 32 matches 2 (Group E winner or best third-placed team) and 5 (Group I winner or best third-placed team).
+The 89th game of the FIFA World Cup 2026 – a Round of 16 match at Lincoln Financial Field, Philadelphia. Features the winners of Round of 32 matches 2 (Group E winner or third-placed team) and 5 (Group I winner or third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-2.md
+++ b/src/_content/games/world-cup-2026/round-of-16-2.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 1 winner v Round of 32 match 3 winner"
+date: 2026-07-04T17:00Z
+endDate: 2026-07-04T19:00Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/round-of-16-2/
+tags: ["Round of 16", "Houston", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Houston. Features the winners of Round of 32 matches 1 (Group A runner-up vs Group B runner-up) and 3 (Group F winner vs Group C runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-2.md
+++ b/src/_content/games/world-cup-2026/round-of-16-2.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-2/
 tags: ["Round of 16", "Houston", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Houston. Features the winners of Round of 32 matches 1 (Group A runner-up vs Group B runner-up) and 3 (Group F winner vs Group C runner-up).
+The 90th game of the FIFA World Cup 2026 – a Round of 16 match at NRG Stadium, Houston. Features the winners of Round of 32 matches 1 (Group A runner-up vs Group B runner-up) and 3 (Group F winner vs Group C runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-3.md
+++ b/src/_content/games/world-cup-2026/round-of-16-3.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 4 winner v Round of 32 match 6 winner"
+date: 2026-07-05T20:00Z
+endDate: 2026-07-05T22:00Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/round-of-16-3/
+tags: ["Round of 16", "New York New Jersey", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at New York/New Jersey. Features the winners of Round of 32 matches 4 (Group C winner vs Group F runner-up) and 6 (Group E runner-up vs Group I runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-3.md
+++ b/src/_content/games/world-cup-2026/round-of-16-3.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-3/
 tags: ["Round of 16", "New York New Jersey", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at New York/New Jersey. Features the winners of Round of 32 matches 4 (Group C winner vs Group F runner-up) and 6 (Group E runner-up vs Group I runner-up).
+The 91st game of the FIFA World Cup 2026 – a Round of 16 match at MetLife Stadium, New York/New Jersey. Features the winners of Round of 32 matches 4 (Group C winner vs Group F runner-up) and 6 (Group E runner-up vs Group I runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-4.md
+++ b/src/_content/games/world-cup-2026/round-of-16-4.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-4/
 tags: ["Round of 16", "Mexico City", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Mexico City. Features the winners of Round of 32 matches 7 (Group A winner vs best third-placed team) and 8 (Group L winner vs best third-placed team).
+The 92nd game of the FIFA World Cup 2026 – a Round of 16 match at Estadio Azteca, Mexico City. Features the winners of Round of 32 matches 7 (Group A winner vs third-placed team) and 8 (Group L winner vs third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-4.md
+++ b/src/_content/games/world-cup-2026/round-of-16-4.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 7 winner v Round of 32 match 8 winner"
+date: 2026-07-06T00:00Z
+endDate: 2026-07-06T02:00Z
+locationName: "Estadio Azteca, Mexico City"
+path: /world-cup-2026/round-of-16-4/
+tags: ["Round of 16", "Mexico City", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Mexico City. Features the winners of Round of 32 matches 7 (Group A winner vs best third-placed team) and 8 (Group L winner vs best third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-5.md
+++ b/src/_content/games/world-cup-2026/round-of-16-5.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-5/
 tags: ["Round of 16", "Dallas", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Dallas. Features the winners of Round of 32 matches 11 (Group K runner-up vs Group L runner-up) and 12 (Group H winner vs Group J runner-up).
+The 93rd game of the FIFA World Cup 2026 – a Round of 16 match at AT&T Stadium, Dallas. Features the winners of Round of 32 matches 11 (Group K runner-up vs Group L runner-up) and 12 (Group H winner vs Group J runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-5.md
+++ b/src/_content/games/world-cup-2026/round-of-16-5.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 11 winner v Round of 32 match 12 winner"
+date: 2026-07-06T19:00Z
+endDate: 2026-07-06T21:00Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/round-of-16-5/
+tags: ["Round of 16", "Dallas", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Dallas. Features the winners of Round of 32 matches 11 (Group K runner-up vs Group L runner-up) and 12 (Group H winner vs Group J runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-6.md
+++ b/src/_content/games/world-cup-2026/round-of-16-6.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 9 winner v Round of 32 match 10 winner"
+date: 2026-07-07T00:00Z
+endDate: 2026-07-07T02:00Z
+locationName: "Lumen Field, Seattle"
+path: /world-cup-2026/round-of-16-6/
+tags: ["Round of 16", "Seattle", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Seattle. Features the winners of Round of 32 matches 9 (Group D winner vs best third-placed team) and 10 (Group G winner vs best third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-6.md
+++ b/src/_content/games/world-cup-2026/round-of-16-6.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-6/
 tags: ["Round of 16", "Seattle", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Seattle. Features the winners of Round of 32 matches 9 (Group D winner vs best third-placed team) and 10 (Group G winner vs best third-placed team).
+The 94th game of the FIFA World Cup 2026 – a Round of 16 match at Lumen Field, Seattle. Features the winners of Round of 32 matches 9 (Group D winner vs third-placed team) and 10 (Group G winner vs third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-7.md
+++ b/src/_content/games/world-cup-2026/round-of-16-7.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 14 winner v Round of 32 match 16 winner"
+date: 2026-07-07T16:00Z
+endDate: 2026-07-07T18:00Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/round-of-16-7/
+tags: ["Round of 16", "Atlanta", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Atlanta. Features the winners of Round of 32 matches 14 (Group J winner vs Group H runner-up) and 16 (Group D runner-up vs Group G runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-7.md
+++ b/src/_content/games/world-cup-2026/round-of-16-7.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-7/
 tags: ["Round of 16", "Atlanta", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Atlanta. Features the winners of Round of 32 matches 14 (Group J winner vs Group H runner-up) and 16 (Group D runner-up vs Group G runner-up).
+The 95th game of the FIFA World Cup 2026 – a Round of 16 match at Mercedes-Benz Stadium, Atlanta. Features the winners of Round of 32 matches 14 (Group J winner vs Group H runner-up) and 16 (Group D runner-up vs Group G runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-8.md
+++ b/src/_content/games/world-cup-2026/round-of-16-8.md
@@ -1,0 +1,10 @@
+---
+title: "Round of 32 match 13 winner v Round of 32 match 15 winner"
+date: 2026-07-07T20:00Z
+endDate: 2026-07-07T22:00Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/round-of-16-8/
+tags: ["Round of 16", "Vancouver", "World Cup 2026"]
+tv: []
+---
+Round of 16 match in the FIFA World Cup 2026 at Vancouver. Features the winners of Round of 32 matches 13 (Group B winner vs best third-placed team) and 15 (Group K winner vs best third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-8.md
+++ b/src/_content/games/world-cup-2026/round-of-16-8.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-16-8/
 tags: ["Round of 16", "Vancouver", "World Cup 2026"]
 tv: []
 ---
-Round of 16 match in the FIFA World Cup 2026 at Vancouver. Features the winners of Round of 32 matches 13 (Group B winner vs best third-placed team) and 15 (Group K winner vs best third-placed team).
+The 96th game of the FIFA World Cup 2026 – a Round of 16 match at BC Place, Vancouver. Features the winners of Round of 32 matches 13 (Group B winner vs third-placed team) and 15 (Group K winner vs third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-32-1.md
+++ b/src/_content/games/world-cup-2026/round-of-32-1.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-1/
 tags: ["Group A", "Group B", "Los Angeles", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group A runner-up and Group B runner-up.
+The 73rd game of the FIFA World Cup 2026 – a Round of 32 match between Group A runner-up and Group B runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-1.md
+++ b/src/_content/games/world-cup-2026/round-of-32-1.md
@@ -1,0 +1,10 @@
+---
+title: "Group A runner-up v Group B runner-up"
+date: 2026-06-28T19:00Z
+endDate: 2026-06-28T21:00Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/round-of-32-1/
+tags: ["Group A", "Group B", "Los Angeles", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group A runner-up and Group B runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-10.md
+++ b/src/_content/games/world-cup-2026/round-of-32-10.md
@@ -1,0 +1,10 @@
+---
+title: "Group G winner v best third-placed team"
+date: 2026-07-01T20:00Z
+endDate: 2026-07-01T22:00Z
+locationName: "Lumen Field, Seattle"
+path: /world-cup-2026/round-of-32-10/
+tags: ["Group G", "Seattle", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group G winner and the best third-placed team (from Groups A, E, H, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-10.md
+++ b/src/_content/games/world-cup-2026/round-of-32-10.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-10/
 tags: ["Group G", "Seattle", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group G winner and the best third-placed team (from Groups A, E, H, I or J).
+The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Group G winner and the best third-placed team (from Groups A, E, H, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-11/
 tags: ["Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group K runner-up and Group L runner-up.
+The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Group K runner-up and Group L runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -1,0 +1,10 @@
+---
+title: "Group K runner-up v Group L runner-up"
+date: 2026-07-02T23:00Z
+endDate: 2026-07-03T01:00Z
+locationName: "BMO Field, Toronto"
+path: /world-cup-2026/round-of-32-11/
+tags: ["Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group K runner-up and Group L runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -1,0 +1,10 @@
+---
+title: "Group H winner v Group J runner-up"
+date: 2026-07-02T19:00Z
+endDate: 2026-07-02T21:00Z
+locationName: "SoFi Stadium, Los Angeles"
+path: /world-cup-2026/round-of-32-12/
+tags: ["Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group H winner and Group J runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-12/
 tags: ["Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group H winner and Group J runner-up.
+The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Group H winner and Group J runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-13/
 tags: ["Group B", "Vancouver", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group B winner and the best third-placed team (from Groups E, F, G, I or J).
+The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Group B winner and the best third-placed team (from Groups E, F, G, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -1,0 +1,10 @@
+---
+title: "Group B winner v best third-placed team"
+date: 2026-07-03T03:00Z
+endDate: 2026-07-03T05:00Z
+locationName: "BC Place, Vancouver"
+path: /world-cup-2026/round-of-32-13/
+tags: ["Group B", "Vancouver", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group B winner and the best third-placed team (from Groups E, F, G, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-14.md
+++ b/src/_content/games/world-cup-2026/round-of-32-14.md
@@ -1,0 +1,10 @@
+---
+title: "Group J winner v Group H runner-up"
+date: 2026-07-03T22:00Z
+endDate: 2026-07-04T00:00Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/round-of-32-14/
+tags: ["Group H", "Group J", "Miami", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group J winner and Group H runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-14.md
+++ b/src/_content/games/world-cup-2026/round-of-32-14.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-14/
 tags: ["Group H", "Group J", "Miami", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group J winner and Group H runner-up.
+The 86th game of the FIFA World Cup 2026 – a Round of 32 match between Group J winner and Group H runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -1,0 +1,10 @@
+---
+title: "Group K winner v best third-placed team"
+date: 2026-07-04T01:30Z
+endDate: 2026-07-04T03:30Z
+locationName: "Arrowhead Stadium, Kansas City"
+path: /world-cup-2026/round-of-32-15/
+tags: ["Group K", "Kansas City", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group K winner and the best third-placed team (from Groups D, E, I, J or L).

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-15/
 tags: ["Group K", "Kansas City", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group K winner and the best third-placed team (from Groups D, E, I, J or L).
+The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Group K winner and the best third-placed team (from Groups D, E, I, J or L).

--- a/src/_content/games/world-cup-2026/round-of-32-16.md
+++ b/src/_content/games/world-cup-2026/round-of-32-16.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-16/
 tags: ["Group D", "Group G", "Dallas", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group D runner-up and Group G runner-up.
+The 88th game of the FIFA World Cup 2026 – a Round of 32 match between Group D runner-up and Group G runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-16.md
+++ b/src/_content/games/world-cup-2026/round-of-32-16.md
@@ -1,0 +1,10 @@
+---
+title: "Group D runner-up v Group G runner-up"
+date: 2026-07-03T18:00Z
+endDate: 2026-07-03T20:00Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/round-of-32-16/
+tags: ["Group D", "Group G", "Dallas", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group D runner-up and Group G runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-2.md
+++ b/src/_content/games/world-cup-2026/round-of-32-2.md
@@ -1,0 +1,10 @@
+---
+title: "Group E winner v best third-placed team"
+date: 2026-06-29T20:30Z
+endDate: 2026-06-29T22:30Z
+locationName: "Gillette Stadium, Boston"
+path: /world-cup-2026/round-of-32-2/
+tags: ["Group E", "Boston", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group E winner and the best third-placed team (from Groups A, B, C, D or F).

--- a/src/_content/games/world-cup-2026/round-of-32-2.md
+++ b/src/_content/games/world-cup-2026/round-of-32-2.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-2/
 tags: ["Group E", "Boston", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group E winner and the best third-placed team (from Groups A, B, C, D or F).
+The 74th game of the FIFA World Cup 2026 – a Round of 32 match between Group E winner and the best third-placed team (from Groups A, B, C, D or F).

--- a/src/_content/games/world-cup-2026/round-of-32-3.md
+++ b/src/_content/games/world-cup-2026/round-of-32-3.md
@@ -1,0 +1,10 @@
+---
+title: "Group F winner v Group C runner-up"
+date: 2026-06-30T01:00Z
+endDate: 2026-06-30T03:00Z
+locationName: "Estadio BBVA, Monterrey"
+path: /world-cup-2026/round-of-32-3/
+tags: ["Group C", "Group F", "Monterrey", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group F winner and Group C runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-3.md
+++ b/src/_content/games/world-cup-2026/round-of-32-3.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-3/
 tags: ["Group C", "Group F", "Monterrey", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group F winner and Group C runner-up.
+The 75th game of the FIFA World Cup 2026 – a Round of 32 match between Group F winner and Group C runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-4.md
+++ b/src/_content/games/world-cup-2026/round-of-32-4.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-4/
 tags: ["Group C", "Group F", "Houston", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group C winner and Group F runner-up.
+The 76th game of the FIFA World Cup 2026 – a Round of 32 match between Group C winner and Group F runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-4.md
+++ b/src/_content/games/world-cup-2026/round-of-32-4.md
@@ -1,0 +1,10 @@
+---
+title: "Group C winner v Group F runner-up"
+date: 2026-06-29T17:00Z
+endDate: 2026-06-29T19:00Z
+locationName: "NRG Stadium, Houston"
+path: /world-cup-2026/round-of-32-4/
+tags: ["Group C", "Group F", "Houston", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group C winner and Group F runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-5.md
+++ b/src/_content/games/world-cup-2026/round-of-32-5.md
@@ -1,0 +1,10 @@
+---
+title: "Group I winner v best third-placed team"
+date: 2026-06-29T21:00Z
+endDate: 2026-06-29T23:00Z
+locationName: "MetLife Stadium, New York New Jersey"
+path: /world-cup-2026/round-of-32-5/
+tags: ["Group I", "New York New Jersey", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group I winner and the best third-placed team (from Groups C, D, F, G or H).

--- a/src/_content/games/world-cup-2026/round-of-32-5.md
+++ b/src/_content/games/world-cup-2026/round-of-32-5.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-5/
 tags: ["Group I", "New York New Jersey", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group I winner and the best third-placed team (from Groups C, D, F, G or H).
+The 77th game of the FIFA World Cup 2026 – a Round of 32 match between Group I winner and the best third-placed team (from Groups C, D, F, G or H).

--- a/src/_content/games/world-cup-2026/round-of-32-6.md
+++ b/src/_content/games/world-cup-2026/round-of-32-6.md
@@ -1,0 +1,10 @@
+---
+title: "Group E runner-up v Group I runner-up"
+date: 2026-06-30T17:00Z
+endDate: 2026-06-30T19:00Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/round-of-32-6/
+tags: ["Group E", "Group I", "Dallas", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group E runner-up and Group I runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-6.md
+++ b/src/_content/games/world-cup-2026/round-of-32-6.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-6/
 tags: ["Group E", "Group I", "Dallas", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group E runner-up and Group I runner-up.
+The 78th game of the FIFA World Cup 2026 – a Round of 32 match between Group E runner-up and Group I runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -1,0 +1,10 @@
+---
+title: "Group A winner v best third-placed team"
+date: 2026-07-01T01:00Z
+endDate: 2026-07-01T03:00Z
+locationName: "Estadio Azteca, Mexico City"
+path: /world-cup-2026/round-of-32-7/
+tags: ["Group A", "Mexico City", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group A winner and the best third-placed team (from Groups C, E, F, H or I).

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-7/
 tags: ["Group A", "Mexico City", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group A winner and the best third-placed team (from Groups C, E, F, H or I).
+The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Group A winner and the best third-placed team (from Groups C, E, F, H or I).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -1,0 +1,10 @@
+---
+title: "Group L winner v best third-placed team"
+date: 2026-07-01T16:00Z
+endDate: 2026-07-01T18:00Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/round-of-32-8/
+tags: ["Group L", "Atlanta", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group L winner and the best third-placed team (from Groups E, H, I, J or K).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-8/
 tags: ["Group L", "Atlanta", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group L winner and the best third-placed team (from Groups E, H, I, J or K).
+The 80th game of the FIFA World Cup 2026 – a Round of 32 match between Group L winner and the best third-placed team (from Groups E, H, I, J or K).

--- a/src/_content/games/world-cup-2026/round-of-32-9.md
+++ b/src/_content/games/world-cup-2026/round-of-32-9.md
@@ -1,0 +1,10 @@
+---
+title: "Group D winner v best third-placed team"
+date: 2026-07-02T00:00Z
+endDate: 2026-07-02T02:00Z
+locationName: "Levi's Stadium, San Francisco"
+path: /world-cup-2026/round-of-32-9/
+tags: ["Group D", "San Francisco", "Round of 32", "World Cup 2026"]
+tv: []
+---
+Round of 32 match in the FIFA World Cup 2026 between Group D winner and the best third-placed team (from Groups B, E, F, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-9.md
+++ b/src/_content/games/world-cup-2026/round-of-32-9.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/round-of-32-9/
 tags: ["Group D", "San Francisco", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-Round of 32 match in the FIFA World Cup 2026 between Group D winner and the best third-placed team (from Groups B, E, F, I or J).
+The 81st game of the FIFA World Cup 2026 – a Round of 32 match between Group D winner and the best third-placed team (from Groups B, E, F, I or J).

--- a/src/_content/games/world-cup-2026/semi-final-1.md
+++ b/src/_content/games/world-cup-2026/semi-final-1.md
@@ -1,0 +1,10 @@
+---
+title: "Quarter-final 1 winner v Quarter-final 2 winner"
+date: 2026-07-14T18:00Z
+endDate: 2026-07-14T20:00Z
+locationName: "AT&T Stadium, Dallas"
+path: /world-cup-2026/semi-final-1/
+tags: ["Semi-final", "Dallas", "World Cup 2026"]
+tv: []
+---
+Semi-final in the FIFA World Cup 2026 at Dallas. Features the winners of quarter-finals 1 (Boston) and 2 (Los Angeles).

--- a/src/_content/games/world-cup-2026/semi-final-1.md
+++ b/src/_content/games/world-cup-2026/semi-final-1.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/semi-final-1/
 tags: ["Semi-final", "Dallas", "World Cup 2026"]
 tv: []
 ---
-Semi-final in the FIFA World Cup 2026 at Dallas. Features the winners of quarter-finals 1 (Boston) and 2 (Los Angeles).
+The 101st game of the FIFA World Cup 2026 – a semi-final at AT&T Stadium, Dallas. Features the winners of quarter-finals 1 (Boston) and 2 (Los Angeles).

--- a/src/_content/games/world-cup-2026/semi-final-2.md
+++ b/src/_content/games/world-cup-2026/semi-final-2.md
@@ -1,0 +1,10 @@
+---
+title: "Quarter-final 3 winner v Quarter-final 4 winner"
+date: 2026-07-15T19:00Z
+endDate: 2026-07-15T21:00Z
+locationName: "Mercedes-Benz Stadium, Atlanta"
+path: /world-cup-2026/semi-final-2/
+tags: ["Semi-final", "Atlanta", "World Cup 2026"]
+tv: []
+---
+Semi-final in the FIFA World Cup 2026 at Atlanta. Features the winners of quarter-finals 3 (Miami) and 4 (Kansas City).

--- a/src/_content/games/world-cup-2026/semi-final-2.md
+++ b/src/_content/games/world-cup-2026/semi-final-2.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/semi-final-2/
 tags: ["Semi-final", "Atlanta", "World Cup 2026"]
 tv: []
 ---
-Semi-final in the FIFA World Cup 2026 at Atlanta. Features the winners of quarter-finals 3 (Miami) and 4 (Kansas City).
+The 102nd game of the FIFA World Cup 2026 – a semi-final at Mercedes-Benz Stadium, Atlanta. Features the winners of quarter-finals 3 (Miami) and 4 (Kansas City).

--- a/src/_content/games/world-cup-2026/third-place-play-off.md
+++ b/src/_content/games/world-cup-2026/third-place-play-off.md
@@ -7,4 +7,4 @@ path: /world-cup-2026/third-place-play-off/
 tags: ["Third-place play-off", "Miami", "World Cup 2026"]
 tv: []
 ---
-Third-place play-off in the FIFA World Cup 2026 at Miami. Features the losers of the two semi-finals.
+The 103rd game of the FIFA World Cup 2026 – the third-place play-off at Hard Rock Stadium, Miami, between the two semi-final losers.

--- a/src/_content/games/world-cup-2026/third-place-play-off.md
+++ b/src/_content/games/world-cup-2026/third-place-play-off.md
@@ -1,0 +1,10 @@
+---
+title: "Semi-final 1 loser v Semi-final 2 loser"
+date: 2026-07-18T21:00Z
+endDate: 2026-07-18T23:00Z
+locationName: "Hard Rock Stadium, Miami"
+path: /world-cup-2026/third-place-play-off/
+tags: ["Third-place play-off", "Miami", "World Cup 2026"]
+tv: []
+---
+Third-place play-off in the FIFA World Cup 2026 at Miami. Features the losers of the two semi-finals.


### PR DESCRIPTION
## Summary
This PR adds comprehensive fixture data for the FIFA World Cup 2026 knockout stage, including Round of 32, Round of 16, Quarter-finals, Semi-finals, Third-place play-off, and Final matches.

## Key Changes
- **Round of 32 matches (16 files)**: Added all 16 Round of 32 fixtures with dates, times, and venues across North American stadiums
- **Round of 16 matches (8 files)**: Added all 8 Round of 16 fixtures following the knockout bracket progression
- **Quarter-final matches (4 files)**: Added all 4 quarter-final fixtures scheduled across different venues
- **Semi-final matches (2 files)**: Added both semi-final fixtures
- **Third-place play-off**: Added the third-place play-off match
- **Final**: Added the championship final match at MetLife Stadium

## Implementation Details
- Each fixture file follows the standard frontmatter format with title, date, endDate, locationName, path, and tags
- Matches are sequentially numbered (73-104) to track progression through the tournament
- All fixtures include venue information and relevant group/match references in descriptions
- TV broadcast information is currently empty for all matches
- Dates and times are specified in UTC timezone (Z suffix)
- Venues span across the United States, Canada, and Mexico as per the 2026 World Cup host nations

https://claude.ai/code/session_01WpAMH3mViP8kmZrvGgMEuc