### PR TITLE
Remove absoluteUrl filter from internal links

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -63,7 +63,7 @@
                                                                                            
                     Hosted on <a href="https://github.com/">Github Pages</a>.
 
-                    <a href="{{ '/about/' | url | absoluteUrl(config.baseUrl) }}">What's this all about?</a>
+                    <a href="{{ '/about/' | url }}">What's this all about?</a>
                     
                 </p>
             </footer>

--- a/src/_layouts/game.njk
+++ b/src/_layouts/game.njk
@@ -143,11 +143,11 @@ layout: base.njk
 <ul class="inline">
     {% for tag in tags | validTags %}
         <li>
-            <a href="{{ ('/' + (tag | slugify) + '/') | url | absoluteUrl(config.baseUrl) }}" rel="tag">{{ tag }} games</a>
+            <a href="{{ ('/' + (tag | slugify) + '/') | url }}" rel="tag">{{ tag }} games</a>
         </li>
     {% endfor %}
     <li>
-        <a href="{{ '/' | url | absoluteUrl(config.baseUrl) }}" class="all">All games</a>
+        <a href="{{ '/' | url }}" class="all">All games</a>
     </li>
 </ul>
 

--- a/src/_layouts/games.njk
+++ b/src/_layouts/games.njk
@@ -56,7 +56,7 @@ layout: base.njk
                     <time class="dt-end" datetime="{{ game.data.endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}">{{ game.data.endDate | date("yyyy-LL-dd'T'H:mm:ssZZZ") }}</time>
                 </td>
                 <td class="summary">
-                    <a class="p-name u-url" href="{{ game.page.url | url | absoluteUrl(config.baseUrl) }}">{{ game.data.title }}</a>
+                    <a class="p-name u-url" href="{{ game.page.url | url }}">{{ game.data.title }}</a>
                 </td>
             </tr>
         {% endfor %}
@@ -136,5 +136,5 @@ layout: base.njk
 {% endif %}
 <h2>Want more?</h2>
 <p>
-    <a href="{{ '/' | url | absoluteUrl(config.baseUrl) }}">All games</a>
+    <a href="{{ '/' | url }}">All games</a>
 </p>

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,7 +5,7 @@ title: Football times in your calendar
 
 <p class="hero">
     Never miss another football game by subscribing to our
-    calendars in your favourite app. <a href="{{ '/about/' | url | absoluteUrl(config.baseUrl) }}">Find out more</a>
+    calendars in your favourite app. <a href="{{ '/about/' | url }}">Find out more</a>
 </p>
 
 <p class="subscribe">
@@ -21,7 +21,7 @@ title: Football times in your calendar
 <ul class="inline competitions">
   {% for competition in competitions %}
   <li>
-      <a href="{{ competition.path | url | absoluteUrl(config.baseUrl) }}">
+      <a href="{{ competition.path | url }}">
           <h2>{{ competition.title }}</h2>
           <p>{{ competition.start | date('dS LLLL') }}–{{ competition.end | date('dS LLLL yyyy') }}</p>
       </a>


### PR DESCRIPTION
## Summary
Removed the `absoluteUrl(config.baseUrl)` filter from all internal links throughout the codebase. The `| url` filter alone is sufficient for generating proper internal URLs.

## Changes
- **src/_layouts/game.njk**: Removed `absoluteUrl` filter from tag links and "All games" link
- **src/_layouts/games.njk**: Removed `absoluteUrl` filter from game title links and "All games" link
- **src/index.njk**: Removed `absoluteUrl` filter from "Find out more" and competition links
- **src/_layouts/base.njk**: Removed `absoluteUrl` filter from footer "What's this all about?" link

## Implementation Details
The `| url` filter in Eleventy already handles URL transformation appropriately for internal links. The additional `absoluteUrl(config.baseUrl)` call was redundant and has been removed across all templates. This simplifies the template code while maintaining the same functionality.

https://claude.ai/code/session_01ThCCQSa5MPr4ZaANiGcQaK