### PR TITLE
Add confirmed Round of 32 fixtures for FIFA World Cup 2026

### DIFF
--- a/src/_content/games/world-cup-2026/final.md
+++ b/src/_content/games/world-cup-2026/final.md
@@ -4,7 +4,7 @@ date: 2026-07-19T19:00Z
 endDate: 2026-07-19T21:00Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/final/
-tags: ["Final", "New York New Jersey", "World Cup 2026"]
+tags: ["Final", "New York New Jersey", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 104th and final game of the FIFA World Cup 2026 – the Final at MetLife Stadium, New York/New Jersey.

--- a/src/_content/games/world-cup-2026/quarter-final-1.md
+++ b/src/_content/games/world-cup-2026/quarter-final-1.md
@@ -4,7 +4,7 @@ date: 2026-07-09T20:00Z
 endDate: 2026-07-09T22:00Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/quarter-final-1/
-tags: ["Quarter Final", "Boston", "World Cup 2026"]
+tags: ["Quarter Final", "Boston", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 97th game of the FIFA World Cup 2026 – a quarter-final at Gillette Stadium, Boston. Features the winners of Round of 16 matches 1 (Philadelphia) and 2 (Houston).

--- a/src/_content/games/world-cup-2026/quarter-final-2.md
+++ b/src/_content/games/world-cup-2026/quarter-final-2.md
@@ -4,7 +4,7 @@ date: 2026-07-10T19:00Z
 endDate: 2026-07-10T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/quarter-final-2/
-tags: ["Quarter Final", "Los Angeles", "World Cup 2026"]
+tags: ["Quarter Final", "Los Angeles", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 98th game of the FIFA World Cup 2026 – a quarter-final at SoFi Stadium, Los Angeles. Features the winners of Round of 16 matches 5 (Dallas) and 6 (Seattle).

--- a/src/_content/games/world-cup-2026/quarter-final-3.md
+++ b/src/_content/games/world-cup-2026/quarter-final-3.md
@@ -4,7 +4,7 @@ date: 2026-07-11T21:00Z
 endDate: 2026-07-11T23:00Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/quarter-final-3/
-tags: ["Quarter Final", "Miami", "World Cup 2026"]
+tags: ["Quarter Final", "Miami", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 99th game of the FIFA World Cup 2026 – a quarter-final at Hard Rock Stadium, Miami. Features the winners of Round of 16 matches 3 (New York/New Jersey) and 4 (Mexico City).

--- a/src/_content/games/world-cup-2026/quarter-final-4.md
+++ b/src/_content/games/world-cup-2026/quarter-final-4.md
@@ -4,7 +4,7 @@ date: 2026-07-12T01:00Z
 endDate: 2026-07-12T03:00Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/quarter-final-4/
-tags: ["Quarter Final", "Kansas City", "World Cup 2026"]
+tags: ["Quarter Final", "Kansas City", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 100th game of the FIFA World Cup 2026 – a quarter-final at Arrowhead Stadium, Kansas City. Features the winners of Round of 16 matches 7 (Atlanta) and 8 (Vancouver).

--- a/src/_content/games/world-cup-2026/round-of-16-1.md
+++ b/src/_content/games/world-cup-2026/round-of-16-1.md
@@ -4,7 +4,7 @@ date: 2026-07-04T21:00Z
 endDate: 2026-07-04T23:00Z
 locationName: "Lincoln Financial Field, Philadelphia"
 path: /world-cup-2026/round-of-16-1/
-tags: ["Round of 16", "Philadelphia", "World Cup 2026"]
+tags: ["Round of 16", "Philadelphia", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 89th game of the FIFA World Cup 2026 – a Round of 16 match at Lincoln Financial Field, Philadelphia. Features the winners of Round of 32 matches 2 (Group E winner or third-placed team) and 5 (Group I winner or third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-2.md
+++ b/src/_content/games/world-cup-2026/round-of-16-2.md
@@ -4,7 +4,7 @@ date: 2026-07-04T17:00Z
 endDate: 2026-07-04T19:00Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/round-of-16-2/
-tags: ["Round of 16", "Houston", "World Cup 2026"]
+tags: ["Round of 16", "Houston", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 90th game of the FIFA World Cup 2026 – a Round of 16 match at NRG Stadium, Houston. Features the winners of Round of 32 matches 1 (Group A runner-up vs Group B runner-up) and 3 (Group F winner vs Group C runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-3.md
+++ b/src/_content/games/world-cup-2026/round-of-16-3.md
@@ -4,7 +4,7 @@ date: 2026-07-05T20:00Z
 endDate: 2026-07-05T22:00Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/round-of-16-3/
-tags: ["Round of 16", "New York New Jersey", "World Cup 2026"]
+tags: ["Round of 16", "New York New Jersey", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 91st game of the FIFA World Cup 2026 – a Round of 16 match at MetLife Stadium, New York/New Jersey. Features the winners of Round of 32 matches 4 (Group C winner vs Group F runner-up) and 6 (Group E runner-up vs Group I runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-4.md
+++ b/src/_content/games/world-cup-2026/round-of-16-4.md
@@ -4,7 +4,7 @@ date: 2026-07-06T00:00Z
 endDate: 2026-07-06T02:00Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/round-of-16-4/
-tags: ["Round of 16", "Mexico City", "World Cup 2026"]
+tags: ["Round of 16", "Mexico City", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 92nd game of the FIFA World Cup 2026 – a Round of 16 match at Estadio Azteca, Mexico City. Features the winners of Round of 32 matches 7 (Group A winner vs third-placed team) and 8 (Group L winner vs third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-5.md
+++ b/src/_content/games/world-cup-2026/round-of-16-5.md
@@ -4,7 +4,7 @@ date: 2026-07-06T19:00Z
 endDate: 2026-07-06T21:00Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/round-of-16-5/
-tags: ["Round of 16", "Dallas", "World Cup 2026"]
+tags: ["Round of 16", "Dallas", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 93rd game of the FIFA World Cup 2026 – a Round of 16 match at AT&T Stadium, Dallas. Features the winners of Round of 32 matches 11 (Group K runner-up vs Group L runner-up) and 12 (Group H winner vs Group J runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-6.md
+++ b/src/_content/games/world-cup-2026/round-of-16-6.md
@@ -4,7 +4,7 @@ date: 2026-07-07T00:00Z
 endDate: 2026-07-07T02:00Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/round-of-16-6/
-tags: ["Round of 16", "Seattle", "World Cup 2026"]
+tags: ["Round of 16", "Seattle", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 94th game of the FIFA World Cup 2026 – a Round of 16 match at Lumen Field, Seattle. Features the winners of Round of 32 matches 9 (Group D winner vs third-placed team) and 10 (Group G winner vs third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-16-7.md
+++ b/src/_content/games/world-cup-2026/round-of-16-7.md
@@ -4,7 +4,7 @@ date: 2026-07-07T16:00Z
 endDate: 2026-07-07T18:00Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/round-of-16-7/
-tags: ["Round of 16", "Atlanta", "World Cup 2026"]
+tags: ["Round of 16", "Atlanta", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 95th game of the FIFA World Cup 2026 – a Round of 16 match at Mercedes-Benz Stadium, Atlanta. Features the winners of Round of 32 matches 14 (Group J winner vs Group H runner-up) and 16 (Group D runner-up vs Group G runner-up).

--- a/src/_content/games/world-cup-2026/round-of-16-8.md
+++ b/src/_content/games/world-cup-2026/round-of-16-8.md
@@ -4,7 +4,7 @@ date: 2026-07-07T20:00Z
 endDate: 2026-07-07T22:00Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/round-of-16-8/
-tags: ["Round of 16", "Vancouver", "World Cup 2026"]
+tags: ["Round of 16", "Vancouver", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 96th game of the FIFA World Cup 2026 – a Round of 16 match at BC Place, Vancouver. Features the winners of Round of 32 matches 13 (Group B winner vs third-placed team) and 15 (Group K winner vs third-placed team).

--- a/src/_content/games/world-cup-2026/round-of-32-1.md
+++ b/src/_content/games/world-cup-2026/round-of-32-1.md
@@ -1,10 +1,10 @@
 ---
-title: "Group A runner-up v Group B runner-up"
+title: "South Africa v Canada"
 date: 2026-06-28T19:00Z
 endDate: 2026-06-28T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/round-of-32-1/
-tags: ["Group A", "Group B", "Los Angeles", "Round of 32", "World Cup 2026"]
+tags: ["South Africa", "Canada", "Group A", "Group B", "Los Angeles", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 73rd game of the FIFA World Cup 2026 – a Round of 32 match between Group A runner-up and Group B runner-up.
+The 73rd game of the FIFA World Cup 2026 – a Round of 32 match between South Africa (Group A runner-up) and Canada (Group B runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-1.md
+++ b/src/_content/games/world-cup-2026/round-of-32-1.md
@@ -3,8 +3,9 @@ title: "South Africa v Canada"
 date: 2026-06-28T19:00Z
 endDate: 2026-06-28T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
-path: /world-cup-2026/round-of-32-1/
-tags: ["South Africa", "Canada", "Group A", "Group B", "Los Angeles", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/south-africa-canada/
+redirectFrom: /world-cup-2026/round-of-32-1/
+tags: ["South Africa", "Canada", "Group A", "Group B", "Los Angeles", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 73rd game of the FIFA World Cup 2026 – a Round of 32 match between South Africa (Group A runner-up) and Canada (Group B runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-10.md
+++ b/src/_content/games/world-cup-2026/round-of-32-10.md
@@ -1,10 +1,10 @@
 ---
-title: "Group G winner v best third-placed team"
+title: "Belgium v South Korea"
 date: 2026-07-01T20:00Z
 endDate: 2026-07-01T22:00Z
 locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/round-of-32-10/
-tags: ["Group G", "Seattle", "Round of 32", "World Cup 2026"]
+tags: ["Belgium", "South Korea", "Group G", "Group A", "Seattle", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Group G winner and the best third-placed team (from Groups A, E, H, I or J).
+The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Belgium (Group G winner) and South Korea (best third-placed team, from Group A).

--- a/src/_content/games/world-cup-2026/round-of-32-10.md
+++ b/src/_content/games/world-cup-2026/round-of-32-10.md
@@ -1,11 +1,11 @@
 ---
-title: "Belgium v South Korea"
+title: "Belgium v Senegal"
 date: 2026-07-01T20:00Z
 endDate: 2026-07-01T22:00Z
 locationName: "Lumen Field, Seattle"
-path: /world-cup-2026/belgium-south-korea/
+path: /world-cup-2026/belgium-senegal/
 redirectFrom: /world-cup-2026/round-of-32-10/
-tags: ["Belgium", "South Korea", "Group G", "Group A", "Seattle", "Knockout", "Round of 32", "World Cup 2026"]
+tags: ["Belgium", "Senegal", "Group G", "Group I", "Seattle", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Belgium (Group G winner) and South Korea (best third-placed team, from Group A).
+The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Belgium (Group G winner) and Senegal (best third-placed team, from Group I).

--- a/src/_content/games/world-cup-2026/round-of-32-10.md
+++ b/src/_content/games/world-cup-2026/round-of-32-10.md
@@ -3,8 +3,9 @@ title: "Belgium v South Korea"
 date: 2026-07-01T20:00Z
 endDate: 2026-07-01T22:00Z
 locationName: "Lumen Field, Seattle"
-path: /world-cup-2026/round-of-32-10/
-tags: ["Belgium", "South Korea", "Group G", "Group A", "Seattle", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/belgium-south-korea/
+redirectFrom: /world-cup-2026/round-of-32-10/
+tags: ["Belgium", "South Korea", "Group G", "Group A", "Seattle", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Belgium (Group G winner) and South Korea (best third-placed team, from Group A).

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -1,10 +1,10 @@
 ---
-title: "Group K runner-up v Group L runner-up"
+title: "Portugal v Croatia"
 date: 2026-07-02T23:00Z
 endDate: 2026-07-03T01:00Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/round-of-32-11/
-tags: ["Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
+tags: ["Portugal", "Croatia", "Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Group K runner-up and Group L runner-up.
+The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Portugal (Group K runner-up) and Croatia (Group L runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -4,7 +4,7 @@ date: 2026-07-02T23:00Z
 endDate: 2026-07-03T01:00Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/round-of-32-11/
-tags: ["Croatia", "Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
+tags: ["Croatia", "Group K", "Group L", "Toronto", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Group K runner-up and Croatia (Group L runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -1,10 +1,11 @@
 ---
-title: "Group K runner-up v Group L runner-up"
+title: "Portugal v Croatia"
 date: 2026-07-02T23:00Z
 endDate: 2026-07-03T01:00Z
 locationName: "BMO Field, Toronto"
-path: /world-cup-2026/round-of-32-11/
-tags: ["Croatia", "Group K", "Group L", "Toronto", "Knockout", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/portugal-croatia/
+redirectFrom: /world-cup-2026/round-of-32-11/
+tags: ["Portugal", "Croatia", "Group K", "Group L", "Toronto", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Group K runner-up and Croatia (Group L runner-up).
+The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Portugal (Group K runner-up) and Croatia (Group L runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -1,10 +1,10 @@
 ---
-title: "Portugal v Croatia"
+title: "Group K runner-up v Group L runner-up"
 date: 2026-07-02T23:00Z
 endDate: 2026-07-03T01:00Z
 locationName: "BMO Field, Toronto"
 path: /world-cup-2026/round-of-32-11/
-tags: ["Portugal", "Croatia", "Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
+tags: ["Croatia", "Group K", "Group L", "Toronto", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Portugal (Group K runner-up) and Croatia (Group L runner-up).
+The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Group K runner-up and Croatia (Group L runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -1,10 +1,10 @@
 ---
-title: "Group H winner v Group J runner-up"
+title: "Spain v Austria"
 date: 2026-07-02T19:00Z
 endDate: 2026-07-02T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/round-of-32-12/
-tags: ["Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
+tags: ["Spain", "Austria", "Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Group H winner and Group J runner-up.
+The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Austria (Group J runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -1,10 +1,10 @@
 ---
-title: "Spain v Austria"
+title: "Group H winner v Group J runner-up"
 date: 2026-07-02T19:00Z
 endDate: 2026-07-02T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/round-of-32-12/
-tags: ["Spain", "Austria", "Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
+tags: ["Spain", "Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Austria (Group J runner-up).
+The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Group J runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -1,10 +1,11 @@
 ---
-title: "Group H winner v Group J runner-up"
+title: "Spain v Austria"
 date: 2026-07-02T19:00Z
 endDate: 2026-07-02T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
-path: /world-cup-2026/round-of-32-12/
-tags: ["Spain", "Group H", "Group J", "Los Angeles", "Knockout", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/spain-austria/
+redirectFrom: /world-cup-2026/round-of-32-12/
+tags: ["Spain", "Austria", "Group H", "Group J", "Los Angeles", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Group J runner-up.
+The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Austria (Group J runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -4,7 +4,7 @@ date: 2026-07-02T19:00Z
 endDate: 2026-07-02T21:00Z
 locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/round-of-32-12/
-tags: ["Spain", "Group H", "Group J", "Los Angeles", "Round of 32", "World Cup 2026"]
+tags: ["Spain", "Group H", "Group J", "Los Angeles", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Group J runner-up.

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -4,7 +4,7 @@ date: 2026-07-03T03:00Z
 endDate: 2026-07-03T05:00Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/round-of-32-13/
-tags: ["Switzerland", "Group B", "Vancouver", "Round of 32", "World Cup 2026"]
+tags: ["Switzerland", "Group B", "Vancouver", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and the best third-placed team (from Groups E, F, G, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -1,10 +1,10 @@
 ---
-title: "Switzerland v Iran"
+title: "Group B winner v best third-placed team"
 date: 2026-07-03T03:00Z
 endDate: 2026-07-03T05:00Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/round-of-32-13/
-tags: ["Switzerland", "Iran", "Group B", "Group G", "Vancouver", "Round of 32", "World Cup 2026"]
+tags: ["Switzerland", "Group B", "Vancouver", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and Iran (best third-placed team, from Group G).
+The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and the best third-placed team (from Groups E, F, G, I or J).

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -1,10 +1,11 @@
 ---
-title: "Group B winner v best third-placed team"
+title: "Switzerland v Algeria"
 date: 2026-07-03T03:00Z
 endDate: 2026-07-03T05:00Z
 locationName: "BC Place, Vancouver"
-path: /world-cup-2026/round-of-32-13/
-tags: ["Switzerland", "Group B", "Vancouver", "Knockout", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/switzerland-algeria/
+redirectFrom: /world-cup-2026/round-of-32-13/
+tags: ["Switzerland", "Algeria", "Group B", "Group J", "Vancouver", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and the best third-placed team (from Groups E, F, G, I or J).
+The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and Algeria (best third-placed team, from Group J).

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -1,10 +1,10 @@
 ---
-title: "Group B winner v best third-placed team"
+title: "Switzerland v Iran"
 date: 2026-07-03T03:00Z
 endDate: 2026-07-03T05:00Z
 locationName: "BC Place, Vancouver"
 path: /world-cup-2026/round-of-32-13/
-tags: ["Group B", "Vancouver", "Round of 32", "World Cup 2026"]
+tags: ["Switzerland", "Iran", "Group B", "Group G", "Vancouver", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Group B winner and the best third-placed team (from Groups E, F, G, I or J).
+The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and Iran (best third-placed team, from Group G).

--- a/src/_content/games/world-cup-2026/round-of-32-14.md
+++ b/src/_content/games/world-cup-2026/round-of-32-14.md
@@ -1,10 +1,10 @@
 ---
-title: "Group J winner v Group H runner-up"
+title: "Argentina v Cape Verde"
 date: 2026-07-03T22:00Z
 endDate: 2026-07-04T00:00Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/round-of-32-14/
-tags: ["Group H", "Group J", "Miami", "Round of 32", "World Cup 2026"]
+tags: ["Argentina", "Cape Verde", "Group J", "Group H", "Miami", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 86th game of the FIFA World Cup 2026 – a Round of 32 match between Group J winner and Group H runner-up.
+The 86th game of the FIFA World Cup 2026 – a Round of 32 match between Argentina (Group J winner) and Cape Verde (Group H runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-14.md
+++ b/src/_content/games/world-cup-2026/round-of-32-14.md
@@ -3,8 +3,9 @@ title: "Argentina v Cape Verde"
 date: 2026-07-03T22:00Z
 endDate: 2026-07-04T00:00Z
 locationName: "Hard Rock Stadium, Miami"
-path: /world-cup-2026/round-of-32-14/
-tags: ["Argentina", "Cape Verde", "Group J", "Group H", "Miami", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/argentina-cape-verde/
+redirectFrom: /world-cup-2026/round-of-32-14/
+tags: ["Argentina", "Cape Verde", "Group J", "Group H", "Miami", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 86th game of the FIFA World Cup 2026 – a Round of 32 match between Argentina (Group J winner) and Cape Verde (Group H runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -1,10 +1,10 @@
 ---
-title: "Colombia v Ghana"
+title: "Group K winner v best third-placed team"
 date: 2026-07-04T01:30Z
 endDate: 2026-07-04T03:30Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/round-of-32-15/
-tags: ["Colombia", "Ghana", "Group K", "Group L", "Kansas City", "Round of 32", "World Cup 2026"]
+tags: ["Group K", "Kansas City", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Colombia (Group K winner) and Ghana (best third-placed team, from Group L).
+The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Group K winner and the best third-placed team (from Groups D, E, I, J or L).

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -4,7 +4,7 @@ date: 2026-07-04T01:30Z
 endDate: 2026-07-04T03:30Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/round-of-32-15/
-tags: ["Group K", "Kansas City", "Round of 32", "World Cup 2026"]
+tags: ["Group K", "Kansas City", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Group K winner and the best third-placed team (from Groups D, E, I, J or L).

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -1,10 +1,10 @@
 ---
-title: "Group K winner v best third-placed team"
+title: "Colombia v Ghana"
 date: 2026-07-04T01:30Z
 endDate: 2026-07-04T03:30Z
 locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/round-of-32-15/
-tags: ["Group K", "Kansas City", "Round of 32", "World Cup 2026"]
+tags: ["Colombia", "Ghana", "Group K", "Group L", "Kansas City", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Group K winner and the best third-placed team (from Groups D, E, I, J or L).
+The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Colombia (Group K winner) and Ghana (best third-placed team, from Group L).

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -1,10 +1,11 @@
 ---
-title: "Group K winner v best third-placed team"
+title: "Colombia v Ghana"
 date: 2026-07-04T01:30Z
 endDate: 2026-07-04T03:30Z
 locationName: "Arrowhead Stadium, Kansas City"
-path: /world-cup-2026/round-of-32-15/
-tags: ["Group K", "Kansas City", "Knockout", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/colombia-ghana/
+redirectFrom: /world-cup-2026/round-of-32-15/
+tags: ["Colombia", "Ghana", "Group K", "Group L", "Kansas City", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Group K winner and the best third-placed team (from Groups D, E, I, J or L).
+The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Colombia (Group K winner) and Ghana (best third-placed team, from Group L).

--- a/src/_content/games/world-cup-2026/round-of-32-16.md
+++ b/src/_content/games/world-cup-2026/round-of-32-16.md
@@ -1,10 +1,10 @@
 ---
-title: "Group D runner-up v Group G runner-up"
+title: "Australia v Egypt"
 date: 2026-07-03T18:00Z
 endDate: 2026-07-03T20:00Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/round-of-32-16/
-tags: ["Group D", "Group G", "Dallas", "Round of 32", "World Cup 2026"]
+tags: ["Australia", "Egypt", "Group D", "Group G", "Dallas", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 88th game of the FIFA World Cup 2026 – a Round of 32 match between Group D runner-up and Group G runner-up.
+The 88th game of the FIFA World Cup 2026 – a Round of 32 match between Australia (Group D runner-up) and Egypt (Group G runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-16.md
+++ b/src/_content/games/world-cup-2026/round-of-32-16.md
@@ -3,8 +3,9 @@ title: "Australia v Egypt"
 date: 2026-07-03T18:00Z
 endDate: 2026-07-03T20:00Z
 locationName: "AT&T Stadium, Dallas"
-path: /world-cup-2026/round-of-32-16/
-tags: ["Australia", "Egypt", "Group D", "Group G", "Dallas", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/australia-egypt/
+redirectFrom: /world-cup-2026/round-of-32-16/
+tags: ["Australia", "Egypt", "Group D", "Group G", "Dallas", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 88th game of the FIFA World Cup 2026 – a Round of 32 match between Australia (Group D runner-up) and Egypt (Group G runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-2.md
+++ b/src/_content/games/world-cup-2026/round-of-32-2.md
@@ -3,8 +3,9 @@ title: "Germany v Paraguay"
 date: 2026-06-29T20:30Z
 endDate: 2026-06-29T22:30Z
 locationName: "Gillette Stadium, Boston"
-path: /world-cup-2026/round-of-32-2/
-tags: ["Germany", "Paraguay", "Group E", "Group D", "Boston", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/germany-paraguay/
+redirectFrom: /world-cup-2026/round-of-32-2/
+tags: ["Germany", "Paraguay", "Group E", "Group D", "Boston", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 74th game of the FIFA World Cup 2026 – a Round of 32 match between Germany (Group E winner) and Paraguay (best third-placed team, from Group D).

--- a/src/_content/games/world-cup-2026/round-of-32-2.md
+++ b/src/_content/games/world-cup-2026/round-of-32-2.md
@@ -1,10 +1,10 @@
 ---
-title: "Group E winner v best third-placed team"
+title: "Germany v Paraguay"
 date: 2026-06-29T20:30Z
 endDate: 2026-06-29T22:30Z
 locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/round-of-32-2/
-tags: ["Group E", "Boston", "Round of 32", "World Cup 2026"]
+tags: ["Germany", "Paraguay", "Group E", "Group D", "Boston", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 74th game of the FIFA World Cup 2026 – a Round of 32 match between Group E winner and the best third-placed team (from Groups A, B, C, D or F).
+The 74th game of the FIFA World Cup 2026 – a Round of 32 match between Germany (Group E winner) and Paraguay (best third-placed team, from Group D).

--- a/src/_content/games/world-cup-2026/round-of-32-3.md
+++ b/src/_content/games/world-cup-2026/round-of-32-3.md
@@ -1,10 +1,10 @@
 ---
-title: "Group F winner v Group C runner-up"
+title: "Netherlands v Morocco"
 date: 2026-06-30T01:00Z
 endDate: 2026-06-30T03:00Z
 locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/round-of-32-3/
-tags: ["Group C", "Group F", "Monterrey", "Round of 32", "World Cup 2026"]
+tags: ["Netherlands", "Morocco", "Group F", "Group C", "Monterrey", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 75th game of the FIFA World Cup 2026 – a Round of 32 match between Group F winner and Group C runner-up.
+The 75th game of the FIFA World Cup 2026 – a Round of 32 match between Netherlands (Group F winner) and Morocco (Group C runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-3.md
+++ b/src/_content/games/world-cup-2026/round-of-32-3.md
@@ -3,8 +3,9 @@ title: "Netherlands v Morocco"
 date: 2026-06-30T01:00Z
 endDate: 2026-06-30T03:00Z
 locationName: "Estadio BBVA, Monterrey"
-path: /world-cup-2026/round-of-32-3/
-tags: ["Netherlands", "Morocco", "Group F", "Group C", "Monterrey", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/netherlands-morocco/
+redirectFrom: /world-cup-2026/round-of-32-3/
+tags: ["Netherlands", "Morocco", "Group F", "Group C", "Monterrey", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 75th game of the FIFA World Cup 2026 – a Round of 32 match between Netherlands (Group F winner) and Morocco (Group C runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-4.md
+++ b/src/_content/games/world-cup-2026/round-of-32-4.md
@@ -1,10 +1,10 @@
 ---
-title: "Group C winner v Group F runner-up"
+title: "Brazil v Japan"
 date: 2026-06-29T17:00Z
 endDate: 2026-06-29T19:00Z
 locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/round-of-32-4/
-tags: ["Group C", "Group F", "Houston", "Round of 32", "World Cup 2026"]
+tags: ["Brazil", "Japan", "Group C", "Group F", "Houston", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 76th game of the FIFA World Cup 2026 – a Round of 32 match between Group C winner and Group F runner-up.
+The 76th game of the FIFA World Cup 2026 – a Round of 32 match between Brazil (Group C winner) and Japan (Group F runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-4.md
+++ b/src/_content/games/world-cup-2026/round-of-32-4.md
@@ -3,8 +3,9 @@ title: "Brazil v Japan"
 date: 2026-06-29T17:00Z
 endDate: 2026-06-29T19:00Z
 locationName: "NRG Stadium, Houston"
-path: /world-cup-2026/round-of-32-4/
-tags: ["Brazil", "Japan", "Group C", "Group F", "Houston", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/brazil-japan/
+redirectFrom: /world-cup-2026/round-of-32-4/
+tags: ["Brazil", "Japan", "Group C", "Group F", "Houston", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 76th game of the FIFA World Cup 2026 – a Round of 32 match between Brazil (Group C winner) and Japan (Group F runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-5.md
+++ b/src/_content/games/world-cup-2026/round-of-32-5.md
@@ -1,7 +1,7 @@
 ---
 title: "France v Sweden"
-date: 2026-06-29T21:00Z
-endDate: 2026-06-29T23:00Z
+date: 2026-06-30T21:00Z
+endDate: 2026-06-30T23:00Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/france-sweden/
 redirectFrom: /world-cup-2026/round-of-32-5/

--- a/src/_content/games/world-cup-2026/round-of-32-5.md
+++ b/src/_content/games/world-cup-2026/round-of-32-5.md
@@ -1,10 +1,10 @@
 ---
-title: "Group I winner v best third-placed team"
+title: "France v Sweden"
 date: 2026-06-29T21:00Z
 endDate: 2026-06-29T23:00Z
 locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/round-of-32-5/
-tags: ["Group I", "New York New Jersey", "Round of 32", "World Cup 2026"]
+tags: ["France", "Sweden", "Group I", "Group F", "New York New Jersey", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 77th game of the FIFA World Cup 2026 – a Round of 32 match between Group I winner and the best third-placed team (from Groups C, D, F, G or H).
+The 77th game of the FIFA World Cup 2026 – a Round of 32 match between France (Group I winner) and Sweden (best third-placed team, from Group F).

--- a/src/_content/games/world-cup-2026/round-of-32-5.md
+++ b/src/_content/games/world-cup-2026/round-of-32-5.md
@@ -3,8 +3,9 @@ title: "France v Sweden"
 date: 2026-06-29T21:00Z
 endDate: 2026-06-29T23:00Z
 locationName: "MetLife Stadium, New York New Jersey"
-path: /world-cup-2026/round-of-32-5/
-tags: ["France", "Sweden", "Group I", "Group F", "New York New Jersey", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/france-sweden/
+redirectFrom: /world-cup-2026/round-of-32-5/
+tags: ["France", "Sweden", "Group I", "Group F", "New York New Jersey", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 77th game of the FIFA World Cup 2026 – a Round of 32 match between France (Group I winner) and Sweden (best third-placed team, from Group F).

--- a/src/_content/games/world-cup-2026/round-of-32-6.md
+++ b/src/_content/games/world-cup-2026/round-of-32-6.md
@@ -1,10 +1,10 @@
 ---
-title: "Group E runner-up v Group I runner-up"
+title: "Ivory Coast v Norway"
 date: 2026-06-30T17:00Z
 endDate: 2026-06-30T19:00Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/round-of-32-6/
-tags: ["Group E", "Group I", "Dallas", "Round of 32", "World Cup 2026"]
+tags: ["Ivory Coast", "Norway", "Group E", "Group I", "Dallas", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 78th game of the FIFA World Cup 2026 – a Round of 32 match between Group E runner-up and Group I runner-up.
+The 78th game of the FIFA World Cup 2026 – a Round of 32 match between Ivory Coast (Group E runner-up) and Norway (Group I runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-6.md
+++ b/src/_content/games/world-cup-2026/round-of-32-6.md
@@ -3,8 +3,9 @@ title: "Ivory Coast v Norway"
 date: 2026-06-30T17:00Z
 endDate: 2026-06-30T19:00Z
 locationName: "AT&T Stadium, Dallas"
-path: /world-cup-2026/round-of-32-6/
-tags: ["Ivory Coast", "Norway", "Group E", "Group I", "Dallas", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/ivory-coast-norway/
+redirectFrom: /world-cup-2026/round-of-32-6/
+tags: ["Ivory Coast", "Norway", "Group E", "Group I", "Dallas", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 78th game of the FIFA World Cup 2026 – a Round of 32 match between Ivory Coast (Group E runner-up) and Norway (Group I runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -1,10 +1,10 @@
 ---
-title: "Group A winner v best third-placed team"
+title: "Mexico v Ecuador"
 date: 2026-07-01T01:00Z
 endDate: 2026-07-01T03:00Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/round-of-32-7/
-tags: ["Group A", "Mexico City", "Round of 32", "World Cup 2026"]
+tags: ["Mexico", "Ecuador", "Group A", "Group E", "Mexico City", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Group A winner and the best third-placed team (from Groups C, E, F, H or I).
+The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and Ecuador (best third-placed team, from Group E).

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -4,7 +4,7 @@ date: 2026-07-01T01:00Z
 endDate: 2026-07-01T03:00Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/round-of-32-7/
-tags: ["Mexico", "Group A", "Mexico City", "Round of 32", "World Cup 2026"]
+tags: ["Mexico", "Group A", "Mexico City", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and the best third-placed team (from Groups C, E, F, H or I).

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -1,10 +1,10 @@
 ---
-title: "Mexico v Ecuador"
+title: "Group A winner v best third-placed team"
 date: 2026-07-01T01:00Z
 endDate: 2026-07-01T03:00Z
 locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/round-of-32-7/
-tags: ["Mexico", "Ecuador", "Group A", "Group E", "Mexico City", "Round of 32", "World Cup 2026"]
+tags: ["Mexico", "Group A", "Mexico City", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and Ecuador (best third-placed team, from Group E).
+The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and the best third-placed team (from Groups C, E, F, H or I).

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -1,10 +1,11 @@
 ---
-title: "Group A winner v best third-placed team"
+title: "Mexico v Ecuador"
 date: 2026-07-01T01:00Z
 endDate: 2026-07-01T03:00Z
 locationName: "Estadio Azteca, Mexico City"
-path: /world-cup-2026/round-of-32-7/
-tags: ["Mexico", "Group A", "Mexico City", "Knockout", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/mexico-ecuador/
+redirectFrom: /world-cup-2026/round-of-32-7/
+tags: ["Mexico", "Ecuador", "Group A", "Group E", "Mexico City", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and the best third-placed team (from Groups C, E, F, H or I).
+The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and Ecuador (best third-placed team, from Group E).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -1,10 +1,10 @@
 ---
-title: "England v Senegal"
+title: "Group L winner v best third-placed team"
 date: 2026-07-01T16:00Z
 endDate: 2026-07-01T18:00Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/round-of-32-8/
-tags: ["England", "Senegal", "Group L", "Group I", "Atlanta", "Round of 32", "World Cup 2026"]
+tags: ["England", "Group L", "Atlanta", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and Senegal (best third-placed team, from Group I).
+The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and the best third-placed team (from Groups E, H, I, J or K).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -1,10 +1,10 @@
 ---
-title: "Group L winner v best third-placed team"
+title: "England v Senegal"
 date: 2026-07-01T16:00Z
 endDate: 2026-07-01T18:00Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/round-of-32-8/
-tags: ["Group L", "Atlanta", "Round of 32", "World Cup 2026"]
+tags: ["England", "Senegal", "Group L", "Group I", "Atlanta", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 80th game of the FIFA World Cup 2026 – a Round of 32 match between Group L winner and the best third-placed team (from Groups E, H, I, J or K).
+The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and Senegal (best third-placed team, from Group I).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -4,7 +4,7 @@ date: 2026-07-01T16:00Z
 endDate: 2026-07-01T18:00Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/round-of-32-8/
-tags: ["England", "Group L", "Atlanta", "Round of 32", "World Cup 2026"]
+tags: ["England", "Group L", "Atlanta", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and the best third-placed team (from Groups E, H, I, J or K).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -1,10 +1,11 @@
 ---
-title: "Group L winner v best third-placed team"
+title: "England v Congo DR"
 date: 2026-07-01T16:00Z
 endDate: 2026-07-01T18:00Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
-path: /world-cup-2026/round-of-32-8/
-tags: ["England", "Group L", "Atlanta", "Knockout", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/england-congo-dr/
+redirectFrom: /world-cup-2026/round-of-32-8/
+tags: ["England", "Congo DR", "Group L", "Group K", "Atlanta", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and the best third-placed team (from Groups E, H, I, J or K).
+The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and Congo DR (best third-placed team, from Group K).

--- a/src/_content/games/world-cup-2026/round-of-32-9.md
+++ b/src/_content/games/world-cup-2026/round-of-32-9.md
@@ -3,8 +3,9 @@ title: "USA v Bosnia and Herzegovina"
 date: 2026-07-02T00:00Z
 endDate: 2026-07-02T02:00Z
 locationName: "Levi's Stadium, San Francisco"
-path: /world-cup-2026/round-of-32-9/
-tags: ["USA", "Bosnia and Herzegovina", "Group D", "Group B", "San Francisco", "Round of 32", "World Cup 2026"]
+path: /world-cup-2026/usa-bosnia-and-herzegovina/
+redirectFrom: /world-cup-2026/round-of-32-9/
+tags: ["USA", "Bosnia and Herzegovina", "Group D", "Group B", "San Francisco", "Knockout", "Round of 32", "World Cup 2026"]
 tv: []
 ---
 The 81st game of the FIFA World Cup 2026 – a Round of 32 match between USA (Group D winner) and Bosnia and Herzegovina (best third-placed team, from Group B).

--- a/src/_content/games/world-cup-2026/round-of-32-9.md
+++ b/src/_content/games/world-cup-2026/round-of-32-9.md
@@ -1,10 +1,10 @@
 ---
-title: "Group D winner v best third-placed team"
+title: "USA v Bosnia and Herzegovina"
 date: 2026-07-02T00:00Z
 endDate: 2026-07-02T02:00Z
 locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/round-of-32-9/
-tags: ["Group D", "San Francisco", "Round of 32", "World Cup 2026"]
+tags: ["USA", "Bosnia and Herzegovina", "Group D", "Group B", "San Francisco", "Round of 32", "World Cup 2026"]
 tv: []
 ---
-The 81st game of the FIFA World Cup 2026 – a Round of 32 match between Group D winner and the best third-placed team (from Groups B, E, F, I or J).
+The 81st game of the FIFA World Cup 2026 – a Round of 32 match between USA (Group D winner) and Bosnia and Herzegovina (best third-placed team, from Group B).

--- a/src/_content/games/world-cup-2026/semi-final-1.md
+++ b/src/_content/games/world-cup-2026/semi-final-1.md
@@ -4,7 +4,7 @@ date: 2026-07-14T18:00Z
 endDate: 2026-07-14T20:00Z
 locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/semi-final-1/
-tags: ["Semi Final", "Dallas", "World Cup 2026"]
+tags: ["Semi Final", "Dallas", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 101st game of the FIFA World Cup 2026 – a semi-final at AT&T Stadium, Dallas. Features the winners of quarter-finals 1 (Boston) and 2 (Los Angeles).

--- a/src/_content/games/world-cup-2026/semi-final-2.md
+++ b/src/_content/games/world-cup-2026/semi-final-2.md
@@ -4,7 +4,7 @@ date: 2026-07-15T19:00Z
 endDate: 2026-07-15T21:00Z
 locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/semi-final-2/
-tags: ["Semi Final", "Atlanta", "World Cup 2026"]
+tags: ["Semi Final", "Atlanta", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 102nd game of the FIFA World Cup 2026 – a semi-final at Mercedes-Benz Stadium, Atlanta. Features the winners of quarter-finals 3 (Miami) and 4 (Kansas City).

--- a/src/_content/games/world-cup-2026/third-place-play-off.md
+++ b/src/_content/games/world-cup-2026/third-place-play-off.md
@@ -4,7 +4,7 @@ date: 2026-07-18T21:00Z
 endDate: 2026-07-18T23:00Z
 locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/third-place-play-off/
-tags: ["Third-place play-off", "Miami", "World Cup 2026"]
+tags: ["Third-place play-off", "Miami", "Knockout", "World Cup 2026"]
 tv: []
 ---
 The 103rd game of the FIFA World Cup 2026 – the third-place play-off at Hard Rock Stadium, Miami, between the two semi-final losers.


### PR DESCRIPTION
Populate all 16 Round of 32 files with actual team names based on
completed group stage standings. 10 fixtures are fully confirmed from
finished groups; 6 are based on near-certain projections pending today's
Group J and K final matchday games (Austria/Algeria and Colombia/Portugal).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TQmoASEJ1yYTASs5wuy3eB