### PR TITLE
Break up game title team names by "v" with responsive layout

### DIFF
--- a/src/_assets/css/_layout.css
+++ b/src/_assets/css/_layout.css
@@ -693,6 +693,52 @@ ul.competitions li {
   word-break: keep-all;
 }
 
+/* ── Game title: team names split by "v" ──────────────────────────────── */
+
+#content .event-post .p-name {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.05em;
+}
+
+.match-vs {
+  font-size: 0.45em;
+  letter-spacing: 0.15em;
+  opacity: 0.65;
+  line-height: 1.5;
+}
+
+.match-vs::before {
+  content: "\2014\00A0\00A0";
+}
+
+.match-vs::after {
+  content: "\00A0\00A0\2014";
+}
+
+@media only screen and (width >= 540px) {
+  #content .event-post .p-name {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 0 0.4em;
+  }
+
+  .event-post .p-name .team-home {
+    text-align: right;
+  }
+
+  .event-post .p-name .team-away {
+    text-align: left;
+  }
+
+  .match-vs::before,
+  .match-vs::after {
+    content: "";
+  }
+}
+
 
 .lede {
   margin-bottom: 5rem;

--- a/src/_assets/css/_layout.css
+++ b/src/_assets/css/_layout.css
@@ -695,6 +695,40 @@ ul.competitions li {
 
 /* ── Game title: team names split by "v" ──────────────────────────────── */
 
+@keyframes slide-from-left {
+  from {
+    opacity: 0;
+    transform: translateX(-3rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-from-right {
+  from {
+    opacity: 0;
+    transform: translateX(3rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes fade-in-vs {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 0.65;
+  }
+}
+
 #content .event-post .p-name {
   display: flex;
   flex-direction: column;
@@ -715,6 +749,26 @@ ul.competitions li {
 
 .match-vs::after {
   content: "\00A0\00A0\2014";
+}
+
+.event-post .p-name .team-home {
+  animation: slide-from-left 1s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.event-post .p-name .match-vs {
+  animation: fade-in-vs 1s ease-out 1s both;
+}
+
+.event-post .p-name .team-away {
+  animation: slide-from-right 1s cubic-bezier(0.22, 1, 0.36, 1) 2s both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .event-post .p-name .team-home,
+  .event-post .p-name .match-vs,
+  .event-post .p-name .team-away {
+    animation: none;
+  }
 }
 
 @media only screen and (width >= 540px) {

--- a/src/_layouts/game.njk
+++ b/src/_layouts/game.njk
@@ -6,10 +6,14 @@ layout: base.njk
     {% for comp in competitions %}{% if comp.title in tags or (comp.shortTitle and comp.shortTitle in tags) %}{% set competitionName = comp.title %}{% endif %}{% endfor %}
     {% if competitionName %}<div class="competition">{{ competitionName }}</div>{% endif %}
 
-    <h1 class="p-name">{{ title }}</h1>
-
     {%- set t1Name = title.split(' v ')[0] %}
     {%- set t2Name = title.split(' v ')[1] %}
+
+    <h1 class="p-name">
+        <span class="team-name team-home">{{ t1Name }}</span>
+        <span class="match-vs">v</span>
+        <span class="team-name team-away">{{ t2Name }}</span>
+    </h1>
     {%- set t1 = teams[t1Name] %}
     {%- set t2 = teams[t2Name] %}
     {%- if t1 or t2 %}


### PR DESCRIPTION
On small screens, the "v" sits on its own line in a smaller font with
em dashes on either side. On larger screens (≥540px), the title switches
to a 3-column grid with the home team right-aligned, "v" centred, and
the away team left-aligned.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QcgP96J4UuMH6oUsh23Pr9