### PR TITLE
Add changelog system to track site updates via Claude Code sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/check-changelog.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,42 @@ For TV listings specifically:
 
 All kick-off times in frontmatter must be in **UTC** (`Z` suffix). Match duration defaults to 1h45m if `endDate` is omitted; set `endDate` explicitly to the expected full-time (plus stoppage time buffer, typically `+1h50m`).
 
+## Changelog
+
+**Every time you make changes and commit/push, you must create a changelog entry.** This is mandatory, not optional.
+
+### How to create an entry
+
+1. Create a file at `src/_content/changelog/YYYY-MM-DD-short-slug.md` using today's date and a brief slug describing the change.
+2. Use this frontmatter — all fields are required except `pr`:
+
+```yaml
+---
+date: 2026-06-28T10:30:00Z
+summary: "One sentence describing what changed and why."
+commit: "https://github.com/sportstimes/footballcal-11ty/commit/<full-hash>"
+pr: "https://github.com/sportstimes/footballcal-11ty/pull/<number>"
+---
+```
+
+- `date`: ISO 8601 UTC timestamp of when the change was made.
+- `summary`: A single clear sentence — what changed and the reason/benefit.
+- `commit`: Full GitHub URL to the commit. Get the hash with `git rev-parse HEAD` after committing.
+- `pr`: GitHub PR URL if one was created; omit the line entirely if not.
+
+3. **Include the changelog file in the same commit as the changes**, or as an immediately following commit if the changes were already pushed.
+4. Run `git rev-parse HEAD` after committing to get the hash, then update `commit:` in the entry before or alongside pushing.
+
+### Naming convention
+
+| Change type | Example filename |
+|---|---|
+| New competition data | `2026-06-28-add-world-cup-2026-group-stage.md` |
+| Bug fix | `2026-06-28-fix-ics-timezone-offset.md` |
+| Feature / page | `2026-06-28-add-changelog-page.md` |
+| Content update | `2026-06-28-update-world-cup-tv-listings.md` |
+| Config / tooling | `2026-06-28-add-claude-stop-hook.md` |
+
 ## JavaScript Style
 
 Uses [StandardJS](https://standardjs.com/) — no semicolons, 2-space indent. Run `npm run lint:js:fix` to auto-fix. CSS uses Stylelint with `stylelint-config-standard`.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -29,6 +29,10 @@ module.exports = config => {
   config.addCollection('redirects', (collectionApi) => {
     return collectionApi.getAll().filter(item => item.data.redirectFrom)
   })
+  config.addCollection('changelogEntries', (collectionApi) => {
+    return collectionApi.getFilteredByTag('changelog')
+      .sort((a, b) => b.date - a.date)
+  })
 
   // methods…
   config.addNunjucksGlobal('showDate', showDate)

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Runs as a Claude Code Stop hook.
+# Warns if the latest commit doesn't include a changelog entry.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Get files changed in the latest commit
+CHANGED=$(git -C "$REPO_ROOT" show --name-only --format="" HEAD 2>/dev/null)
+
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+# Check if any changelog file was part of the latest commit
+CHANGELOG_IN_COMMIT=$(echo "$CHANGED" | grep "^src/_content/changelog/")
+
+# Check if only changelog files changed (skip in that case)
+NON_CHANGELOG=$(echo "$CHANGED" | grep -v "^src/_content/changelog/")
+
+if [ -n "$NON_CHANGELOG" ] && [ -z "$CHANGELOG_IN_COMMIT" ]; then
+  echo ""
+  echo "⚠️  Changelog reminder: The latest commit does not include a changelog entry."
+  echo "   Add a file to src/_content/changelog/ describing this change."
+  echo "   See CLAUDE.md for the required frontmatter format."
+  echo ""
+fi

--- a/src/_content/changelog/2026-06-28-add-changelog-system.md
+++ b/src/_content/changelog/2026-06-28-add-changelog-system.md
@@ -1,0 +1,7 @@
+---
+date: 2026-06-28T00:00:00Z
+summary: "Add changelog system to track all site updates made via Claude Code sessions."
+commit: ""
+---
+
+Introduced a changelog system consisting of a content directory (`src/_content/changelog/`) for per-change Markdown entries, an Eleventy collection, and a public list page at `/changelog/`. A Claude Code Stop hook (`scripts/check-changelog.sh`) warns if a commit is made without an accompanying entry. Instructions added to `CLAUDE.md` make changelog creation mandatory for all future Claude Code sessions.

--- a/src/_content/changelog/2026-06-28-add-changelog-system.md
+++ b/src/_content/changelog/2026-06-28-add-changelog-system.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-06-28T00:00:00Z
 summary: "Add changelog system to track all site updates made via Claude Code sessions."
-commit: ""
+commit: "https://github.com/sportstimes/footballcal-11ty/commit/f0cd0430c6a3d39f2f9e076fe5152815b9b412c9"
 ---
 
 Introduced a changelog system consisting of a content directory (`src/_content/changelog/`) for per-change Markdown entries, an Eleventy collection, and a public list page at `/changelog/`. A Claude Code Stop hook (`scripts/check-changelog.sh`) warns if a commit is made without an accompanying entry. Instructions added to `CLAUDE.md` make changelog creation mandatory for all future Claude Code sessions.

--- a/src/_content/changelog/changelog.11tydata.js
+++ b/src/_content/changelog/changelog.11tydata.js
@@ -1,0 +1,4 @@
+module.exports = {
+  tags: ['changelog'],
+  permalink: false
+}

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -63,7 +63,8 @@
                                                                                            
                     Hosted on <a href="https://github.com/">Github Pages</a>.
 
-                    <a href="{{ '/about/' | url }}">What's this all about?</a>
+                    <a href="{{ '/about/' | url }}">What's this all about?</a> |
+                    <a href="{{ '/changelog/' | url }}">Changelog</a>
                     
                 </p>
             </footer>

--- a/src/changelog.njk
+++ b/src/changelog.njk
@@ -1,0 +1,21 @@
+---
+title: Changelog
+layout: base.njk
+pageDescription: "A record of all updates and changes made to Football Cal."
+---
+<h1>Changelog</h1>
+<p>A log of updates to Football Cal, in reverse chronological order.</p>
+
+<ul class="changelog">
+  {% for entry in collections.changelogEntries %}
+  <li>
+    <time datetime="{{ entry.date | date('yyyy-LL-dd') }}">{{ entry.date | date("dS LLLL yyyy") }}</time>
+    — {{ entry.data.summary }}
+    {% if entry.data.pr %}
+      <a href="{{ entry.data.pr }}">view PR</a>
+    {% elif entry.data.commit %}
+      <a href="{{ entry.data.commit }}">view commit</a>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>

--- a/src/tags.md
+++ b/src/tags.md
@@ -7,6 +7,9 @@ pagination:
   filter:
     - all
     - webcal-game
+    - changelog
+    - changelogEntries
+    - redirects
 permalink: /{{ tag | slugify }}/
 eleventyComputed:
   title: "{{ tag }} Games"


### PR DESCRIPTION
- src/_content/changelog/ directory with per-change Markdown entries
- Eleventy collection (changelogEntries) sorted reverse-chronologically
- Public list page at /changelog/ linked from the site footer
- Stop hook (scripts/check-changelog.sh) warns if a commit omits an entry
- CLAUDE.md updated with mandatory changelog creation instructions
- tags.md updated to exclude internal collections from tag page generation

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TotP55QQeAaC1n7og5n1W