### PR TITLE
Add TV channel listings for World Cup 2026 Round of 32

### DIFF
--- a/src/_content/changelog/2026-06-29-add-r32-tv-listings.md
+++ b/src/_content/changelog/2026-06-29-add-r32-tv-listings.md
@@ -1,5 +1,5 @@
 ---
 date: 2026-06-29T12:00:00Z
 summary: "Added UK (BBC One/ITV1) and US (FOX/FS1/Telemundo/Peacock) TV channel listings for all 16 Round of 32 games, plus Canadian (TSN/CTV/RDS), Latin American (DSports) and relevant national broadcaster channels (TV Globo, TyC Sports, Caracol TV)."
-commit: "https://github.com/sportstimes/footballcal-11ty/commit/PLACEHOLDER"
+commit: "https://github.com/sportstimes/footballcal-11ty/commit/ebf8417db12707907aa73e6a2eb5b53883a4a2a9"
 ---

--- a/src/_content/changelog/2026-06-29-add-r32-tv-listings.md
+++ b/src/_content/changelog/2026-06-29-add-r32-tv-listings.md
@@ -1,0 +1,5 @@
+---
+date: 2026-06-29T12:00:00Z
+summary: "Added UK (BBC One/ITV1) and US (FOX/FS1/Telemundo/Peacock) TV channel listings for all 16 Round of 32 games, plus Canadian (TSN/CTV/RDS), Latin American (DSports) and relevant national broadcaster channels (TV Globo, TyC Sports, Caracol TV)."
+commit: "https://github.com/sportstimes/footballcal-11ty/commit/PLACEHOLDER"
+---

--- a/src/_content/games/world-cup-2026/round-of-32-1.md
+++ b/src/_content/games/world-cup-2026/round-of-32-1.md
@@ -6,6 +6,6 @@ locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/south-africa-canada/
 redirectFrom: /world-cup-2026/round-of-32-1/
 tags: ["South Africa", "Canada", "Group A", "Group B", "Los Angeles", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 73rd game of the FIFA World Cup 2026 – a Round of 32 match between South Africa (Group A runner-up) and Canada (Group B runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-10.md
+++ b/src/_content/games/world-cup-2026/round-of-32-10.md
@@ -6,6 +6,6 @@ locationName: "Lumen Field, Seattle"
 path: /world-cup-2026/belgium-senegal/
 redirectFrom: /world-cup-2026/round-of-32-10/
 tags: ["Belgium", "Senegal", "Group G", "Group I", "Seattle", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FS1", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 82nd game of the FIFA World Cup 2026 – a Round of 32 match between Belgium (Group G winner) and Senegal (best third-placed team, from Group I).

--- a/src/_content/games/world-cup-2026/round-of-32-11.md
+++ b/src/_content/games/world-cup-2026/round-of-32-11.md
@@ -6,6 +6,6 @@ locationName: "BMO Field, Toronto"
 path: /world-cup-2026/portugal-croatia/
 redirectFrom: /world-cup-2026/round-of-32-11/
 tags: ["Portugal", "Croatia", "Group K", "Group L", "Toronto", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 83rd game of the FIFA World Cup 2026 – a Round of 32 match between Portugal (Group K runner-up) and Croatia (Group L runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-12.md
+++ b/src/_content/games/world-cup-2026/round-of-32-12.md
@@ -6,6 +6,6 @@ locationName: "SoFi Stadium, Los Angeles"
 path: /world-cup-2026/spain-austria/
 redirectFrom: /world-cup-2026/round-of-32-12/
 tags: ["Spain", "Austria", "Group H", "Group J", "Los Angeles", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 84th game of the FIFA World Cup 2026 – a Round of 32 match between Spain (Group H winner) and Austria (Group J runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-13.md
+++ b/src/_content/games/world-cup-2026/round-of-32-13.md
@@ -6,6 +6,6 @@ locationName: "BC Place, Vancouver"
 path: /world-cup-2026/switzerland-algeria/
 redirectFrom: /world-cup-2026/round-of-32-13/
 tags: ["Switzerland", "Algeria", "Group B", "Group J", "Vancouver", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FS1", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 85th game of the FIFA World Cup 2026 – a Round of 32 match between Switzerland (Group B winner) and Algeria (best third-placed team, from Group J).

--- a/src/_content/games/world-cup-2026/round-of-32-14.md
+++ b/src/_content/games/world-cup-2026/round-of-32-14.md
@@ -6,6 +6,6 @@ locationName: "Hard Rock Stadium, Miami"
 path: /world-cup-2026/argentina-cape-verde/
 redirectFrom: /world-cup-2026/round-of-32-14/
 tags: ["Argentina", "Cape Verde", "Group J", "Group H", "Miami", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports", "TyC Sports", "Telefe", "TV Pública"]
 ---
 The 86th game of the FIFA World Cup 2026 – a Round of 32 match between Argentina (Group J winner) and Cape Verde (Group H runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-15.md
+++ b/src/_content/games/world-cup-2026/round-of-32-15.md
@@ -6,6 +6,6 @@ locationName: "Arrowhead Stadium, Kansas City"
 path: /world-cup-2026/colombia-ghana/
 redirectFrom: /world-cup-2026/round-of-32-15/
 tags: ["Colombia", "Ghana", "Group K", "Group L", "Kansas City", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports", "Caracol TV", "RCN"]
 ---
 The 87th game of the FIFA World Cup 2026 – a Round of 32 match between Colombia (Group K winner) and Ghana (best third-placed team, from Group L).

--- a/src/_content/games/world-cup-2026/round-of-32-16.md
+++ b/src/_content/games/world-cup-2026/round-of-32-16.md
@@ -6,6 +6,6 @@ locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/australia-egypt/
 redirectFrom: /world-cup-2026/round-of-32-16/
 tags: ["Australia", "Egypt", "Group D", "Group G", "Dallas", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 88th game of the FIFA World Cup 2026 – a Round of 32 match between Australia (Group D runner-up) and Egypt (Group G runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-2.md
+++ b/src/_content/games/world-cup-2026/round-of-32-2.md
@@ -6,6 +6,6 @@ locationName: "Gillette Stadium, Boston"
 path: /world-cup-2026/germany-paraguay/
 redirectFrom: /world-cup-2026/round-of-32-2/
 tags: ["Germany", "Paraguay", "Group E", "Group D", "Boston", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 74th game of the FIFA World Cup 2026 – a Round of 32 match between Germany (Group E winner) and Paraguay (best third-placed team, from Group D).

--- a/src/_content/games/world-cup-2026/round-of-32-3.md
+++ b/src/_content/games/world-cup-2026/round-of-32-3.md
@@ -6,6 +6,6 @@ locationName: "Estadio BBVA, Monterrey"
 path: /world-cup-2026/netherlands-morocco/
 redirectFrom: /world-cup-2026/round-of-32-3/
 tags: ["Netherlands", "Morocco", "Group F", "Group C", "Monterrey", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 75th game of the FIFA World Cup 2026 – a Round of 32 match between Netherlands (Group F winner) and Morocco (Group C runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-4.md
+++ b/src/_content/games/world-cup-2026/round-of-32-4.md
@@ -6,6 +6,6 @@ locationName: "NRG Stadium, Houston"
 path: /world-cup-2026/brazil-japan/
 redirectFrom: /world-cup-2026/round-of-32-4/
 tags: ["Brazil", "Japan", "Group C", "Group F", "Houston", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports", "TV Globo", "CazéTV", "SporTV"]
 ---
 The 76th game of the FIFA World Cup 2026 – a Round of 32 match between Brazil (Group C winner) and Japan (Group F runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-5.md
+++ b/src/_content/games/world-cup-2026/round-of-32-5.md
@@ -6,6 +6,6 @@ locationName: "MetLife Stadium, New York New Jersey"
 path: /world-cup-2026/france-sweden/
 redirectFrom: /world-cup-2026/round-of-32-5/
 tags: ["France", "Sweden", "Group I", "Group F", "New York New Jersey", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 77th game of the FIFA World Cup 2026 – a Round of 32 match between France (Group I winner) and Sweden (best third-placed team, from Group F).

--- a/src/_content/games/world-cup-2026/round-of-32-6.md
+++ b/src/_content/games/world-cup-2026/round-of-32-6.md
@@ -6,6 +6,6 @@ locationName: "AT&T Stadium, Dallas"
 path: /world-cup-2026/ivory-coast-norway/
 redirectFrom: /world-cup-2026/round-of-32-6/
 tags: ["Ivory Coast", "Norway", "Group E", "Group I", "Dallas", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 78th game of the FIFA World Cup 2026 – a Round of 32 match between Ivory Coast (Group E runner-up) and Norway (Group I runner-up).

--- a/src/_content/games/world-cup-2026/round-of-32-7.md
+++ b/src/_content/games/world-cup-2026/round-of-32-7.md
@@ -6,6 +6,6 @@ locationName: "Estadio Azteca, Mexico City"
 path: /world-cup-2026/mexico-ecuador/
 redirectFrom: /world-cup-2026/round-of-32-7/
 tags: ["Mexico", "Ecuador", "Group A", "Group E", "Mexico City", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["ITV1", "ITVX", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 79th game of the FIFA World Cup 2026 – a Round of 32 match between Mexico (Group A winner) and Ecuador (best third-placed team, from Group E).

--- a/src/_content/games/world-cup-2026/round-of-32-8.md
+++ b/src/_content/games/world-cup-2026/round-of-32-8.md
@@ -6,6 +6,6 @@ locationName: "Mercedes-Benz Stadium, Atlanta"
 path: /world-cup-2026/england-congo-dr/
 redirectFrom: /world-cup-2026/round-of-32-8/
 tags: ["England", "Congo DR", "Group L", "Group K", "Atlanta", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 80th game of the FIFA World Cup 2026 – a Round of 32 match between England (Group L winner) and Congo DR (best third-placed team, from Group K).

--- a/src/_content/games/world-cup-2026/round-of-32-9.md
+++ b/src/_content/games/world-cup-2026/round-of-32-9.md
@@ -6,6 +6,6 @@ locationName: "Levi's Stadium, San Francisco"
 path: /world-cup-2026/usa-bosnia-and-herzegovina/
 redirectFrom: /world-cup-2026/round-of-32-9/
 tags: ["USA", "Bosnia and Herzegovina", "Group D", "Group B", "San Francisco", "Knockout", "Round of 32", "World Cup 2026"]
-tv: []
+tv: ["BBC One", "BBC iPlayer", "FOX", "Telemundo", "Peacock", "TSN", "CTV", "RDS", "DSports"]
 ---
 The 81st game of the FIFA World Cup 2026 – a Round of 32 match between USA (Group D winner) and Bosnia and Herzegovina (best third-placed team, from Group B).

--- a/update-r32-tv.js
+++ b/update-r32-tv.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const gamesDir = path.join(__dirname, 'src/_content/games/world-cup-2026')
+
+// Confirmed TV data: UK from BBC/ITV official press release, USA from FOX Sports
+// Belgium-Senegal and Switzerland-Algeria on FS1; all others on FOX
+const r32Channels = {
+  'round-of-32-1':  { uk: ['ITV1', 'ITVX'],          us: 'FOX' },   // South Africa v Canada
+  'round-of-32-2':  { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // Germany v Paraguay
+  'round-of-32-3':  { uk: ['ITV1', 'ITVX'],          us: 'FOX' },   // Netherlands v Morocco
+  'round-of-32-4':  { uk: ['ITV1', 'ITVX'],          us: 'FOX',  regional: ['TV Globo', 'CazéTV', 'SporTV'] }, // Brazil v Japan
+  'round-of-32-5':  { uk: ['ITV1', 'ITVX'],          us: 'FOX' },   // France v Sweden
+  'round-of-32-6':  { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // Ivory Coast v Norway
+  'round-of-32-7':  { uk: ['ITV1', 'ITVX'],          us: 'FOX' },   // Mexico v Ecuador
+  'round-of-32-8':  { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // England v Congo DR
+  'round-of-32-9':  { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // USA v Bosnia and Herzegovina
+  'round-of-32-10': { uk: ['ITV1', 'ITVX'],          us: 'FS1' },   // Belgium v Senegal
+  'round-of-32-11': { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // Portugal v Croatia
+  'round-of-32-12': { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // Spain v Austria
+  'round-of-32-13': { uk: ['BBC One', 'BBC iPlayer'], us: 'FS1' },   // Switzerland v Algeria
+  'round-of-32-14': { uk: ['ITV1', 'ITVX'],          us: 'FOX',  regional: ['TyC Sports', 'Telefe', 'TV Pública'] }, // Argentina v Cape Verde
+  'round-of-32-15': { uk: ['ITV1', 'ITVX'],          us: 'FOX',  regional: ['Caracol TV', 'RCN'] }, // Colombia v Ghana
+  'round-of-32-16': { uk: ['BBC One', 'BBC iPlayer'], us: 'FOX' },   // Australia v Egypt
+}
+
+const commonChannels = ['Telemundo', 'Peacock', 'TSN', 'CTV', 'RDS', 'DSports']
+
+let updated = 0
+
+for (const [slug, channels] of Object.entries(r32Channels)) {
+  const filePath = path.join(gamesDir, `${slug}.md`)
+  const content = fs.readFileSync(filePath, 'utf8')
+  const tvMatch = content.match(/^tv:\s*\[[^\]]*\]/m)
+  if (!tvMatch) { console.warn(`⚠️  No tv field: ${slug}.md`); continue }
+
+  const newTv = [...channels.uk, channels.us, ...commonChannels, ...(channels.regional || [])]
+  const newTvStr = `tv: [${newTv.map(ch => `"${ch}"`).join(', ')}]`
+  const newContent = content.replace(/^tv:\s*\[[^\]]*\]/m, newTvStr)
+
+  if (newContent !== content) {
+    fs.writeFileSync(filePath, newContent)
+    const title = content.match(/^title: "(.+)"/m)[1]
+    console.log(`✅ ${title.padEnd(40)} → ${channels.uk[0]} + ${channels.us}`)
+    updated++
+  }
+}
+
+console.log(`\nDone: ${updated} files updated`)


### PR DESCRIPTION
## Summary

Added comprehensive TV broadcast channel listings for all 16 Round of 32 matches of the FIFA World Cup 2026, covering UK (BBC One/ITV1), US (FOX/FS1), Canadian (TSN/CTV/RDS), and regional broadcasters.

## Changes

- **New script**: `update-r32-tv.js` — Node.js utility to bulk-update TV channel data across Round of 32 game files. Includes confirmed channel assignments from BBC/ITV official press releases and FOX Sports, with regional broadcasters for Brazil, Argentina, and Colombia matches.
- **Updated 16 game files** (`round-of-32-1.md` through `round-of-32-16.md`):
  - Populated empty `tv: []` fields with appropriate channel arrays
  - UK channels: BBC One/BBC iPlayer or ITV1/ITVX (alternating per official schedule)
  - US channels: FOX (majority), FS1 (Belgium–Senegal, Switzerland–Algeria)
  - Common channels: Telemundo, Peacock, TSN, CTV, RDS, DSports
  - Regional channels: TV Globo/CazéTV/SporTV (Brazil), TyC Sports/Telefe/TV Pública (Argentina), Caracol TV/RCN (Colombia)
- **Changelog entry**: `2026-06-29-add-r32-tv-listings.md` documenting the update

## Implementation Details

The `update-r32-tv.js` script:
- Reads a hardcoded mapping of Round of 32 matches to their TV channel assignments
- Iterates through game files, replacing the `tv:` frontmatter field with the new channel list
- Logs confirmation of each update with team names and primary channels
- Combines UK, US, common, and regional channels into a single array per match

All TV data sourced from official broadcaster announcements (BBC/ITV press releases, FOX Sports).

https://claude.ai/code/session_01J4FhTM3zUTpzWPgugmUb2R