### PR TITLE
Redesign changelog as vertical timeline with linked date/time and fix invalid date rendering

### DIFF
--- a/src/_assets/css/_changelog.css
+++ b/src/_assets/css/_changelog.css
@@ -1,0 +1,89 @@
+/* ── Changelog timeline ─────────────────────────────────────────────────── */
+
+#content h1.changelog-title {
+  font-size: clamp(1.5rem, 8vw, 2.25rem);
+}
+
+.changelog-timeline {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  position: relative;
+}
+
+/* Continuous vertical line running through all entries */
+.changelog-timeline::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-1px);
+  background: rgb(255 255 255 / 30%);
+  z-index: 0;
+}
+
+.changelog-entry {
+  margin: 0;
+  padding: 0;
+}
+
+.changelog-row {
+  display: grid;
+  grid-template-columns: 1fr 4rem 1fr;
+  align-items: center;
+  min-height: 4rem;
+}
+
+.changelog-node {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 4rem;
+  position: relative;
+  z-index: 1;
+}
+
+.changelog-dot {
+  display: inline-block;
+  width: 3rem;
+  height: 3rem;
+  background: #fff;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.changelog-date,
+.changelog-time {
+  font-family: 'DIN Condensed Bold', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.85rem;
+  color: #fff;
+  border-bottom: none;
+  line-height: 1.2;
+}
+
+.changelog-date {
+  text-align: right;
+  padding-right: 0.75rem;
+}
+
+.changelog-time {
+  padding-left: 0.75rem;
+  color: rgb(255 255 255 / 80%);
+}
+
+.changelog-date:hover,
+.changelog-time:hover {
+  border-bottom: 2px solid rgb(255 255 255 / 60%);
+}
+
+.changelog-desc {
+  color: #fff;
+  margin: 0 0 1rem;
+  padding: 0.25rem 0 0.75rem;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}

--- a/src/_assets/css/site.css
+++ b/src/_assets/css/site.css
@@ -2,6 +2,7 @@
 @import url("_header.css");
 @import url("_subscribe.css");
 @import url("_event.css");
+@import url("_changelog.css");
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@900&display=swap');
 
 #cookie-banner {

--- a/src/_content/changelog/2026-06-30-changelog-cosmetic-updates.md
+++ b/src/_content/changelog/2026-06-30-changelog-cosmetic-updates.md
@@ -1,0 +1,5 @@
+---
+date: 2026-06-30T00:00:00Z
+summary: "Redesigned changelog page as a vertical timeline with date on the left, dot in the centre, and time on the right — all linked to the commit — fixing invalid date rendering and reducing the title font size for mobile viewports."
+commit: "https://github.com/sportstimes/footballcal-11ty/commit/71335c56173e5cc9ccf1462bb68f1c203581ff2e"
+---

--- a/src/_filters/date.js
+++ b/src/_filters/date.js
@@ -6,7 +6,10 @@ function ordinal (n) {
   return "'" + n + (s[(v - 20) % 10] || s[v] || s[0]) + "' "
 }
 
-module.exports = (date, format, locale = 'en') => {
-  date = DateTime.fromISO(date).setLocale(locale)
-  return date.toFormat(format.replace('dS ', ordinal(date.day)))
+module.exports = (dateVal, format, locale = 'en') => {
+  const dt = (dateVal instanceof Date
+    ? DateTime.fromJSDate(dateVal, { zone: 'utc' })
+    : DateTime.fromISO(dateVal)
+  ).setLocale(locale)
+  return dt.toFormat(format.replace('dS ', ordinal(dt.day)))
 }

--- a/src/changelog.njk
+++ b/src/changelog.njk
@@ -3,19 +3,29 @@ title: Changelog
 layout: base.njk
 pageDescription: "A record of all updates and changes made to Football Cal."
 ---
-<h1>Changelog</h1>
+<h1 class="changelog-title">Changelog</h1>
 <p>A log of updates to Football Cal, in reverse chronological order.</p>
 
-<ul class="changelog">
+<ol class="changelog-timeline">
   {% for entry in collections.changelogEntries %}
-  <li>
-    <time datetime="{{ entry.date | date('yyyy-LL-dd') }}">{{ entry.date | date("dS LLLL yyyy") }}</time>
-    — {{ entry.data.summary }}
-    {% if entry.data.pr %}
-      <a href="{{ entry.data.pr }}">view PR</a>
-    {% elif entry.data.commit %}
-      <a href="{{ entry.data.commit }}">view commit</a>
-    {% endif %}
+  {% set commitLink = entry.data.commit or entry.data.pr %}
+  <li class="changelog-entry">
+    <div class="changelog-row">
+      {% if commitLink %}
+      <a class="changelog-date" href="{{ commitLink }}">{{ entry.data.date | date("d LLL yyyy") }}</a>
+      {% else %}
+      <span class="changelog-date">{{ entry.data.date | date("d LLL yyyy") }}</span>
+      {% endif %}
+      <div class="changelog-node" aria-hidden="true">
+        <span class="changelog-dot"></span>
+      </div>
+      {% if commitLink %}
+      <a class="changelog-time" href="{{ commitLink }}">{{ entry.data.date | date("HH:mm") }}</a>
+      {% else %}
+      <span class="changelog-time">{{ entry.data.date | date("HH:mm") }}</span>
+      {% endif %}
+    </div>
+    <p class="changelog-desc">{{ entry.data.summary }}</p>
   </li>
   {% endfor %}
-</ul>
+</ol>


### PR DESCRIPTION
- Fix date filter to handle JS Date objects (fromJSDate) alongside ISO strings
- Rebuild changelog.njk as a vertical timeline: date on left, dot in centre, time on right, linked to commit; full-width summary below
- Add _changelog.css with responsive title font-size and continuous connecting timeline line
- Import _changelog.css into site.css

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WJ6DC7jqUZVXtc2zGPnh3u