### PR TITLE
Confirm World Cup 2026 Round of 16 fixtures 4 and 6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ The Round of 16 (and later QF/SF/Final) files are pre-created as placeholders (`
 4. **Build (`npm run build`) and spot-check** the generated page/`.ics`/`_redirects` entry for each updated match before committing.
 5. **Add a changelog entry** per the Changelog section below, summarising which match numbers were confirmed and what's still pending TV info.
 
-Status as of 2026-07-01: R16 matches 1–3 confirmed (Paraguay v France, Canada v Morocco, Brazil v Norway — all Round of 32 feeders 1–6 finished). Matches 4–8 depend on Round of 32 matches 7–16, which are still being played July 1–4; revisit each morning as more of those conclude.
+Status as of 2026-07-02: R16 matches 1–4 and 6 confirmed. Matches 1–3 (Paraguay v France, Canada v Morocco, Brazil v Norway) confirmed 2026-07-01 from Round of 32 feeders 1–6. Matches 4 and 6 (Mexico v England, USA v Belgium) confirmed 2026-07-02 from Round of 32 feeders 7–10. Matches 5, 7 and 8 depend on Round of 32 matches 11–16, which are being played July 2–4; revisit each morning as more of those conclude.
 
 ## Changelog
 

--- a/src/_content/changelog/2026-07-02-confirm-r16-fixtures-4-and-6.md
+++ b/src/_content/changelog/2026-07-02-confirm-r16-fixtures-4-and-6.md
@@ -1,0 +1,5 @@
+---
+date: 2026-07-02T09:35:00Z
+summary: "Confirmed two more Round of 16 fixtures after last night's Round of 32 games: Mexico v England (Estadio Azteca, Mexico City) and USA v Belgium (Lumen Field, Seattle). Results verified against FIFA.com, ESPN, England Football and CBS News."
+commit: "PENDING"
+---

--- a/src/_content/changelog/2026-07-02-confirm-r16-fixtures-4-and-6.md
+++ b/src/_content/changelog/2026-07-02-confirm-r16-fixtures-4-and-6.md
@@ -1,5 +1,5 @@
 ---
 date: 2026-07-02T09:35:00Z
 summary: "Confirmed two more Round of 16 fixtures after last night's Round of 32 games: Mexico v England (Estadio Azteca, Mexico City) and USA v Belgium (Lumen Field, Seattle). Results verified against FIFA.com, ESPN, England Football and CBS News."
-commit: "PENDING"
+commit: "https://github.com/sportstimes/footballcal-11ty/commit/76cc41309694fd328f647a44db0e3e6c1fd05124"
 ---

--- a/src/_content/games/world-cup-2026/round-of-16-4.md
+++ b/src/_content/games/world-cup-2026/round-of-16-4.md
@@ -1,10 +1,11 @@
 ---
-title: "Round of 32 match 7 winner v Round of 32 match 8 winner"
+title: "Mexico v England"
 date: 2026-07-06T00:00Z
 endDate: 2026-07-06T02:00Z
 locationName: "Estadio Azteca, Mexico City"
-path: /world-cup-2026/round-of-16-4/
-tags: ["Round of 16", "Mexico City", "Knockout", "World Cup 2026"]
+path: /world-cup-2026/mexico-england/
+redirectFrom: /world-cup-2026/round-of-16-4/
+tags: ["Mexico", "England", "Round of 16", "Mexico City", "Knockout", "World Cup 2026"]
 tv: []
 ---
-The 92nd game of the FIFA World Cup 2026 – a Round of 16 match at Estadio Azteca, Mexico City. Features the winners of Round of 32 matches 7 (Group A winner vs third-placed team) and 8 (Group L winner vs third-placed team).
+The 92nd game of the FIFA World Cup 2026 – a Round of 16 match at Estadio Azteca, Mexico City. Mexico (beat Ecuador 2-0) face England (came from behind to beat DR Congo 2-1, with a Harry Kane brace) in the Round of 32.

--- a/src/_content/games/world-cup-2026/round-of-16-6.md
+++ b/src/_content/games/world-cup-2026/round-of-16-6.md
@@ -1,10 +1,11 @@
 ---
-title: "Round of 32 match 9 winner v Round of 32 match 10 winner"
+title: "USA v Belgium"
 date: 2026-07-07T00:00Z
 endDate: 2026-07-07T02:00Z
 locationName: "Lumen Field, Seattle"
-path: /world-cup-2026/round-of-16-6/
-tags: ["Round of 16", "Seattle", "Knockout", "World Cup 2026"]
+path: /world-cup-2026/usa-belgium/
+redirectFrom: /world-cup-2026/round-of-16-6/
+tags: ["USA", "Belgium", "Round of 16", "Seattle", "Knockout", "World Cup 2026"]
 tv: []
 ---
-The 94th game of the FIFA World Cup 2026 – a Round of 16 match at Lumen Field, Seattle. Features the winners of Round of 32 matches 9 (Group D winner vs third-placed team) and 10 (Group G winner vs third-placed team).
+The 94th game of the FIFA World Cup 2026 – a Round of 16 match at Lumen Field, Seattle. USA (beat Bosnia and Herzegovina 2-0, playing over half the match with ten men) face Belgium (beat Senegal 3-2 after extra time, coming back from 2-0 down) in the Round of 32.


### PR DESCRIPTION
## Summary
- Confirmed two more Round of 16 fixtures now that last night's Round of 32 games have finished: **Mexico v England** (Estadio Azteca, Mexico City, Mon 6 July) and **USA v Belgium** (Lumen Field, Seattle, Mon 6 July / Tue 7 July UTC)
- Updated `title`, `path` (+ `redirectFrom` for the old placeholder URL), `tags`, and description text for `round-of-16-4.md` and `round-of-16-6.md`, following the same pattern used for matches 1-3
- Results double-checked against multiple independent sources: FIFA.com match centre, ESPN, England Football (official), CBS News, NBC Bay Area
- `tv` left empty pending BBC/ITV's per-game channel confirmation, per the existing process
- Updated the "World Cup 2026 Knockout Fixture Tracking" status note in `CLAUDE.md` and added a changelog entry

## Test plan
- [x] `npm run build` completes cleanly
- [x] New pages generated at `/world-cup-2026/mexico-england/` and `/world-cup-2026/usa-belgium/` with correct title/description
- [x] `_redirects` contains 301s from the old `/world-cup-2026/round-of-16-4/` and `/round-of-16-6/` URLs
- [x] `.ics` files generated for both new fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WG5ZR56Ac54opkF4x6dTdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG5ZR56Ac54opkF4x6dTdU)_